### PR TITLE
Unit tests!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+  - "3.6"
+install:
+  - pip install -r requirements.txt
+  - pip install pytest h5py
+script:
+  - pytest test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
 install:
   - pip install -r requirements.txt
+  - pip install .
   - pip install pytest h5py
 script:
   - pytest test

--- a/epsie/chain/chain.py
+++ b/epsie/chain/chain.py
@@ -83,6 +83,8 @@ class Chain(BaseChain):
     hasblobs
     chain_id : int or None
         Integer identifying the chain.
+    proposal_dist : JointProposal
+        The joint proposal used for all parameters.
     """
     def __init__(self, parameters, model, proposals, bit_generator=None,
                  chain_id=0, beta=1.):

--- a/epsie/samplers/ptsampler.py
+++ b/epsie/samplers/ptsampler.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 import numpy
 import copy
 
-from epsie import create_bit_generator
+from epsie import (create_bit_generator, array2dict)
 from epsie.chain import ParallelTemperedChain
 from epsie.chain.chaindata import (ChainData, detect_dtypes)
 
@@ -156,7 +156,7 @@ class ParallelTemperedSampler(BaseSampler):
         out.extend(self.nchains)
         for ii, chain in enumerate(self.chains):
             out[ii] = getattr(chain, attr)
-        return out.asdict()
+        return array2dict(out.data.T)
 
     def _concatenate_arrays(self, attr, item=None):
         """Concatenates the given attribute over all of the chains.

--- a/test/_utils.py
+++ b/test/_utils.py
@@ -14,8 +14,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Utilities for carrying out tests."""
 
+
 import numpy
 from scipy import stats
+import epsie
+
 
 class Model(object):
     """A simple model for testing the samplers.
@@ -82,3 +85,35 @@ class ModelWithBlobs(Model):
             logl, blob = self.loglikelihood(**kwargs)
         return logl, logp, blob
 
+
+def _check_array(array, expected_params, expected_shape):
+    """Helper function to test arrays returned by the sampler."""
+    # check that the fields are the same as the model's
+    assert sorted(array.dtype.names) == sorted(expected_params)
+    # check that the shape is what's expected
+    assert array.shape == expected_shape
+    # check that we can turn this into a dictionary
+    adict = epsie.array2dict(array)
+    assert sorted(adict.keys()) == sorted(expected_params)
+    for param, val in adict.items():
+        assert val.shape == expected_shape
+
+
+def _compare_dict_array(a, b):
+    """Helper function to test if two dictionaries of arrays are the
+    same.
+    """
+    # first check that keys are the same
+    assert list(a.keys()) == list(b.keys())
+    # now check the values
+    assert all([(a[p] == b[p]).all() for p in a])
+
+
+def _anticompare_dict_array(a, b):
+    """Helper function to test if two dictionaries of arrays are the
+    not the same.
+    """
+    # first check that keys are the same
+    assert list(a.keys()) == list(b.keys())
+    # now check the values
+    assert not all([(a[p] == b[p]).all() for p in a])

--- a/test/_utils.py
+++ b/test/_utils.py
@@ -117,3 +117,27 @@ def _anticompare_dict_array(a, b):
     assert list(a.keys()) == list(b.keys())
     # now check the values
     assert not all([(a[p] == b[p]).all() for p in a])
+
+
+def _check_chains_are_different(chain, other, test_blobs,
+                                test_state=True):
+    """Checks that two chains' random states and current positions/stats/blobs
+    are different.
+    """
+    if test_state:
+        rstate = chain.state['proposal_dist']['random_state']
+        ostate = other.state['proposal_dist']['random_state']
+        assert rstate != ostate
+    _anticompare_dict_array(chain.current_position,
+                            other.current_position)
+    _anticompare_dict_array(chain.current_stats,
+                            other.current_stats)
+    if test_blobs:
+        # note: we're checking that the blobs aren't the same, but
+        # it might happen for a model that they would be the same
+        # across chains, depending on the data. The testing models
+        # in utils.py return the value of the log likelihood in
+        # each parameter for the blobs, so we expect them to be
+        # different in this case
+        _anticompare_dict_array(chain.current_blob,
+                                other.current_blob)

--- a/test/_utils.py
+++ b/test/_utils.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2020  Collin Capano
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""Utilities for carrying out tests."""
+
+import numpy
+from scipy import stats
+
+class Model(object):
+    """A simple model for testing the samplers.
+
+    The likelihood function is a 2D gaussian with parameters "x" and "y", which
+    have mean 2, 5 and standard deviation 1 and 2, respectively. The prior is
+    uniform in x, between -20 and 20, and uniform in y, between -40 and 40.
+    """
+    blob_params = None
+
+    def __init__(self):
+        # we'll use a 2D Gaussian for the likelihood distribution
+        self.params = ['x', 'y']
+        self.mean = numpy.array([2., 5.])
+        self.std = numpy.array([1., 2.])
+        self.likelihood_dist = stats.norm(loc=self.mean, scale=self.std)
+        # we'll just use a uniform prior
+        self.prior_bounds = {'x': (-20., 20.),
+                             'y': (-40., 40.)}
+        xmin = self.prior_bounds['x'][0]
+        dx = self.prior_bounds['x'][1] - xmin
+        ymin = self.prior_bounds['y'][0]
+        dy = self.prior_bounds['y'][1] - ymin
+        self.prior_dist = {'x': stats.uniform(xmin, dx),
+                           'y': stats.uniform(ymin, dy)}
+
+    def prior_rvs(self, size=None, shape=None):
+        return {p: self.prior_dist[p].rvs(size=size).reshape(shape)
+                for p in self.params}
+    
+    def logprior(self, **kwargs):
+        return sum([self.prior_dist[p].logpdf(kwargs[p]) for p in self.params])
+    
+    def loglikelihood(self, **kwargs):
+        return self.likelihood_dist.logpdf([kwargs[p]
+                                            for p in self.params]).sum()
+    
+    def __call__(self, **kwargs):
+        logp = self.logprior(**kwargs)
+        if logp == -numpy.inf:
+            logl = None
+        else:
+            logl = self.loglikelihood(**kwargs)
+        return logl, logp
+
+
+class ModelWithBlobs(Model):
+    """Adds blobs to ``Model``.
+
+    The added blobs are the values of the marginal log likelihood of each
+    parameter.
+    """
+    blob_params = ['xlogl', 'ylogl']
+
+    def loglikelihood(self, **kwargs):
+        xlogl, ylogl = self.likelihood_dist.logpdf([kwargs['x'], kwargs['y']])
+        return xlogl+ylogl, {'xlogl': xlogl, 'ylogl': ylogl}
+    
+    def __call__(self, **kwargs):
+        logp = self.logprior(**kwargs)
+        if logp == -numpy.inf:
+            logl = blob = None
+        else:
+            logl, blob = self.loglikelihood(**kwargs)
+        return logl, logp, blob
+

--- a/test/_utils.py
+++ b/test/_utils.py
@@ -48,14 +48,14 @@ class Model(object):
     def prior_rvs(self, size=None, shape=None):
         return {p: self.prior_dist[p].rvs(size=size).reshape(shape)
                 for p in self.params}
-    
+
     def logprior(self, **kwargs):
         return sum([self.prior_dist[p].logpdf(kwargs[p]) for p in self.params])
-    
+
     def loglikelihood(self, **kwargs):
         return self.likelihood_dist.logpdf([kwargs[p]
                                             for p in self.params]).sum()
-    
+
     def __call__(self, **kwargs):
         logp = self.logprior(**kwargs)
         if logp == -numpy.inf:
@@ -76,7 +76,7 @@ class ModelWithBlobs(Model):
     def loglikelihood(self, **kwargs):
         xlogl, ylogl = self.likelihood_dist.logpdf([kwargs['x'], kwargs['y']])
         return xlogl+ylogl, {'xlogl': xlogl, 'ylogl': ylogl}
-    
+
     def __call__(self, **kwargs):
         logp = self.logprior(**kwargs)
         if logp == -numpy.inf:

--- a/test/test_adaptive_normal.py
+++ b/test/test_adaptive_normal.py
@@ -54,7 +54,7 @@ def test_std_changes(nprocs):
     # use the test model
     model = Model()
     # create an adaptive normal instance
-    proposal = _setup_proposal(model) 
+    proposal = _setup_proposal(model)
     # check the proposal's parameters option matches the model's
     assert sorted(proposal.parameters) == sorted(model.params)
     # we'll just use the PTSampler default setup from the ptsampler tests
@@ -76,7 +76,7 @@ def test_std_changes(nprocs):
     for ii, chain in enumerate(sampler.chains):
         for jj, subchain in enumerate(chain.chains):
             thisprop = subchain.proposal_dist.proposals[tuple(model.params)]
-            current_std[ii, jj, :] = thisprop.std 
+            current_std[ii, jj, :] = thisprop.std
     assert (initial_std != current_std).all()
     # now run past the adaptation duration; since we have gone past it, the
     # standard deviations should no longer change
@@ -86,7 +86,7 @@ def test_std_changes(nprocs):
     for ii, chain in enumerate(sampler.chains):
         for jj, subchain in enumerate(chain.chains):
             thisprop = subchain.proposal_dist.proposals[tuple(model.params)]
-            current_std[ii, jj, :] = thisprop.std 
+            current_std[ii, jj, :] = thisprop.std
     assert (previous_std == current_std).all()
 
 
@@ -96,7 +96,7 @@ def test_chains(nprocs):
     proposal.
     """
     model = Model()
-    proposal = _setup_proposal(model) 
+    proposal = _setup_proposal(model)
     _test_chains(Model, nprocs, SWAP_INTERVAL,
                  proposals={tuple(model.params): proposal})
 
@@ -107,7 +107,7 @@ def test_checkpointing(nprocs):
     the adaptive normal proposal.
     """
     model = Model()
-    proposal = _setup_proposal(model) 
+    proposal = _setup_proposal(model)
     _test_checkpointing(Model, nprocs,
                         proposals={tuple(model.params): proposal})
 
@@ -117,7 +117,7 @@ def test_seed(nprocs):
     """Runs the PTSampler ``test_seed`` using the adaptive normal proposal.
     """
     model = Model()
-    proposal = _setup_proposal(model) 
+    proposal = _setup_proposal(model)
     _test_seed(Model, nprocs,
                proposals={tuple(model.params): proposal})
 
@@ -128,6 +128,6 @@ def test_clear_memory(nprocs):
     proposal.
     """
     model = Model()
-    proposal = _setup_proposal(model) 
+    proposal = _setup_proposal(model)
     _test_clear_memory(Model, nprocs, SWAP_INTERVAL,
                        proposals={tuple(model.params): proposal})

--- a/test/test_adaptive_normal.py
+++ b/test/test_adaptive_normal.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2020  Collin Capano
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""Performs unit tests on the AdaptiveNormal proposal."""
+
+from __future__ import (print_function, absolute_import)
+
+import itertools
+import pytest
+import numpy
+
+from epsie.proposals import AdaptiveNormal
+from _utils import Model
+
+from test_ptsampler import _create_sampler
+from test_ptsampler import test_chains as _test_chains
+from test_ptsampler import test_checkpointing as _test_checkpointing
+from test_ptsampler import test_seed as _test_seed
+from test_ptsampler import test_clear_memory as _test_clear_memory
+
+
+ITERINT = 32
+ADAPTATION_DURATION = ITERINT//2
+SWAP_INTERVAL = 1
+
+
+def _setup_proposal(model, adaptation_duration=None):
+    if adaptation_duration is None:
+        adaptation_duration = ADAPTATION_DURATION
+    prior_widths = {p: abs(bnds[1] - bnds[0])
+                    for p, bnds in model.prior_bounds.items()}
+    return AdaptiveNormal(model.params, prior_widths,
+                          adaptation_duration=adaptation_duration)
+
+
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_std_changes(nprocs):
+    """Tests that the standard deviation of the proposal changes after a few
+    jumps.
+    """
+    # use the test model
+    model = Model()
+    # create an adaptive normal instance
+    proposal = _setup_proposal(model) 
+    # check the proposal's parameters option matches the model's
+    assert sorted(proposal.parameters) == sorted(model.params)
+    # we'll just use the PTSampler default setup from the ptsampler tests
+    sampler = _create_sampler(model, nprocs,
+                              proposals={tuple(model.params): proposal})
+    # check that all temperatures and all chains have the same initial
+    # standard deviation as the proposal
+    initial_std = numpy.zeros((sampler.nchains, sampler.ntemps,
+                               len(proposal.parameters)))
+    for ii, chain in enumerate(sampler.chains):
+        for jj, subchain in enumerate(chain.chains):
+            thisprop = subchain.proposal_dist.proposals[tuple(model.params)]
+            assert (thisprop.std == proposal.std).all()
+            initial_std[ii, jj, :] = thisprop.std
+    # run the sampler for the adaptation duration, and check that the standard
+    # deviation of all chains and temperatures has changed
+    sampler.run(ADAPTATION_DURATION)
+    current_std = numpy.zeros(initial_std.shape)
+    for ii, chain in enumerate(sampler.chains):
+        for jj, subchain in enumerate(chain.chains):
+            thisprop = subchain.proposal_dist.proposals[tuple(model.params)]
+            current_std[ii, jj, :] = thisprop.std 
+    assert (initial_std != current_std).all()
+    # now run past the adaptation duration; since we have gone past it, the
+    # standard deviations should no longer change
+    sampler.run(ITERINT//2)
+    previous_std = current_std
+    current_std = numpy.zeros(previous_std.shape)
+    for ii, chain in enumerate(sampler.chains):
+        for jj, subchain in enumerate(chain.chains):
+            thisprop = subchain.proposal_dist.proposals[tuple(model.params)]
+            current_std[ii, jj, :] = thisprop.std 
+    assert (previous_std == current_std).all()
+
+
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_chains(nprocs):
+    """Runs the PTSampler ``test_chains`` test using the adaptive normal
+    proposal.
+    """
+    model = Model()
+    proposal = _setup_proposal(model) 
+    _test_chains(Model, nprocs, SWAP_INTERVAL,
+                 proposals={tuple(model.params): proposal})
+
+
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_checkpointing(nprocs):
+    """Performs the same checkpointing test as for the PTSampler, but using
+    the adaptive normal proposal.
+    """
+    model = Model()
+    proposal = _setup_proposal(model) 
+    _test_checkpointing(Model, nprocs,
+                        proposals={tuple(model.params): proposal})
+
+
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_seed(nprocs):
+    """Runs the PTSampler ``test_seed`` using the adaptive normal proposal.
+    """
+    model = Model()
+    proposal = _setup_proposal(model) 
+    _test_seed(Model, nprocs,
+               proposals={tuple(model.params): proposal})
+
+
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_clear_memory(nprocs):
+    """Runs the PTSampler ``test_clear_memoory`` using the adaptive normal
+    proposal.
+    """
+    model = Model()
+    proposal = _setup_proposal(model) 
+    _test_clear_memory(Model, nprocs, SWAP_INTERVAL,
+                       proposals={tuple(model.params): proposal})

--- a/test/test_mhsampler.py
+++ b/test/test_mhsampler.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python
+
+from __future__ import (print_function, absolute_import)
+
+import unittest
+import itertools
+import multiprocessing
+import numpy
+import randomgen
+import epsie
+from epsie.samplers import MetropolisHastingsSampler
+from _utils import (Model, ModelWithBlobs)
+
+
+def _compare_dict_array(a, b):
+    """Helper function to test if two dictionaries of arrays are the
+    same.
+    """
+    # first check that keys are the same
+    if a.keys() != b.keys():
+        return False
+    return all([(a[p] == b[p]).all() for p in a])
+
+class TestMHSampler(unittest.TestCase):
+    """Runs the MHSampler and runs various tests on it."""
+    nchains = 8
+    nprocs = 1
+    iterint = 32  # standard number of iterations we'll run for
+    seed = 11001001
+    model_cls = Model
+
+    def setUp(self):
+        self.model = self.model_cls()
+        if self.nprocs == 1:
+            self.pool = None
+        else:
+            self.pool = multiprocessing.Pool(self.nprocs)
+        self.start_position = self.model.prior_rvs(size=self.nchains)
+
+    def _create_sampler(self, seed=None, set_start=True):
+        """Creates a sampler."""
+        sampler = MetropolisHastingsSampler(self.model.params, self.model,
+                                            self.nchains, pool=self.pool,
+                                            seed=seed)
+        if set_start:
+            sampler.start_position = self.start_position
+        return sampler
+
+    def _check_array(self, array, expected_params, expected_shape):
+        """Helper function to test arrays returned by the sampler."""
+        # check that the fields are the same as the model's
+        self.assertEqual(sorted(array.dtype.names),
+                         sorted(expected_params),
+                         "Sampler's returned parameters differ from the "
+                         "expected")
+        # check that the shape is what's expected
+        self.assertEqual(array.shape, expected_shape,
+                         "Array does not have the expected shape "
+                         "(expected {},  got {})".format(expected_shape,
+                                                         array.shape))
+        # check that we can turn this into a dictionary
+        adict = epsie.array2dict(array)
+        self.assertEqual(sorted(adict.keys()), sorted(expected_params),
+                         "Not all parameters converted to dictionary")
+        for param, val in adict.items():
+            self.assertEqual(val.shape, expected_shape,
+                             "Dictionary values do not have expected shape "
+                             "(expected {}; got {})".format(expected_shape,
+                                                            val.shape))
+
+    def test_chains(self):
+        """Sets up and runs a sampler for a few iterations, then performs
+        the following checks:
+
+        * That the positions, stats, acceptance ratios, and (if the model
+          returns blobs) blobs all have the expected parameters, shape
+          nchains x niterations, and can be converted to dictionaries of
+          arrays.
+        * That the ``current_(positions|stats|blobs)`` (if the model returns
+          blobs) are the same as the last item in the positions/stats/blobs.
+        * If the model does not return blobs, that the ``blobs`` and
+          ``current_blobs`` are all None.
+        * That the chains all have different random states after the
+          iterations, and different positions/stats/blobs.
+        """
+        sampler = self._create_sampler(self.seed)
+        sampler.run(self.iterint)
+        # check that we get the positions back in the expected format
+        positions = sampler.positions
+        expected_shape = (self.nchains, self.iterint)
+        self._check_array(positions, self.model.params,
+                          expected_shape)
+        # check that the current position is the same as the last in the array
+        comp = _compare_dict_array(epsie.array2dict(positions[..., -1]),
+                                   sampler.current_positions)
+        self.assertTrue(comp,
+                        "Last values in position array are not the same "
+                        "as the current_positions attribute")
+        # check that the stats have the expected fields and shape
+        stats = sampler.stats
+        self._check_array(stats, ['logl', 'logp'],
+                          expected_shape)
+        # check that the current position is the same as the last in the array
+        comp = _compare_dict_array(epsie.array2dict(stats[..., -1]),
+                                   sampler.current_stats)
+        self.assertEqual(comp,
+                         "Last values in stats array are not the same "
+                         "as the current_stats attribute")
+        # check that the acceptance ratios have the expected fields and shape
+        acceptance = sampler.acceptance
+        self._check_array(acceptance, ['acceptance_ratio', 'accepted'],
+                          expected_shape)
+        # check the individual chains
+        for ii, chain in enumerate(sampler.chains):
+            # check that the length matches the number of iterations
+            self.assertEqual(len(chain), self.iterint,
+                             "Length of chain {} is different than the number "
+                             "of iterations".format(ii))
+            # check that hasblobs is None if the model doesn't return any
+            if not self.model.blob_params:
+                self.assertFalse(chain.hasblobs,
+                                 "chain.hasblobs should be false if the model "
+                                 "does not return blobs")
+            else:
+                self.assertTrue(chain.hasblobs,
+                                "chain.hasblobs should be true if the model "
+                                "returns blobs")
+        # check the blobs
+        blobs = sampler.blobs
+        current_blobs = sampler.current_blobs
+        if self.model.blob_params:
+            self._check_array(blobs, self.model.blob_params,
+                              expected_shape)
+            comp = _compare_dict_array(epsie.array2dict(blobs[..., -1]),
+                                       current_blobs)
+            self.assertTrue(comp,
+                            "Last values in the blobs array are not the "
+                            "same as the current_blobs attribute")
+        else:
+            # check that blobs are None since this model doesn't have blobs
+            self.assertTrue(blobs is None,
+                            "Sampler should return None as the blob attribute "
+                            "when the model does not return blobs")
+            self.assertTrue(current_blobs is None,
+                            "current_blobs should be None since the model "
+                            "does not return blobs")
+        # check that each chain's random state and current values are different
+        combos = itertools.combinations(len(sampler.chains), 2)
+        for ii, jj in combos:
+            chain = sampler.chains[ii]
+            other = sampler.chains[jj]
+            rstate = chain.state['proposal_dist']['random_state']
+            ostate = other.state['proposal_dist']['random_state']
+            self.assertNotEqual(rstate, ostate,
+                                "Chains should all have different "
+                                "random states")
+            comp = _compare_dict_array(chain.current_positions,
+                                       other.current_positions)
+            self.assertFalse(comp,
+                             "Chains should all have different current "
+                             "positions")
+            comp = _compare_dict_array(chain.current_stats,
+                                       other.current_stats)
+            self.assertFalse(comp,
+                             "Chains should all have different current "
+                             "positions")
+            if self.model.blob_params:
+                # note: we're checking that the blobs aren't the same, but
+                # it might happen for a model that they would be the same
+                # across chains, depending on the data. The testing models
+                # in utils.py return the value of the log likelihood in
+                # each parameter for the blobs, so we expect them to be
+                # different in this case
+                comp = _compare_dict_array(chain.current_blobs,
+                                           other.current_blobs)
+                self.assertFalse(comp,
+                                 "Chains should all have different blobs "
+                                 "since the tested model returns blob "
+                                 "values that depend on the position")
+
+
+    def test_checkpointing(self):
+        """Tests that resuming from checkpoint yields the same result as if
+        no checkpoint happened.
+        """
+        import h5py
+        sampler = self._create_sampler(self.seed)
+        # create a second sampler for comparison; we won't bother setting
+        # a seed or start position, since that shouldn't matter when loading
+        # from a checkpoint
+        sampler2 = self._create_sampler(set_start=False)
+        sampler.run(self.iterint)
+        # checkpoint to an h5py file in memory
+        fp = h5py.File('test.hdf', 'w', driver='core', backing_store=False)
+        sampler.checkpoint(fp)
+        # run for another set of iterations
+        sampler.run(self.iterint)
+        # set the other sampler's state using the checkpiont
+        sampler2.set_state_from_checkpoint(fp)
+        fp.close()
+        # run again
+        sampler2.run(self.iterint)
+        # compare the two
+        comp = _compare_dict_array(sampler.current_positions,
+                                   sampler2.current_positions)
+        self.assertTrue(comp,
+                        "Resuming from checkpoint did not yield the same "
+                        "positions as running continously")
+        comp = _compare_dict_array(sampler.current_stats,
+                                   sampler2.current_stats)
+        self.assertTrue(comp,
+                        "Resuming from checkpoint did not yield the same "
+                        "stats as running continously")
+        if self.model.blob_params:
+            comp = _compare_dict_array(sampler.current_blobs,
+                                       sampler2.current_blobs)
+            self.assertTrue(comp,
+                            "Resuming from checkpoint did not yield the same "
+                            "blobs as running continously")
+
+    def test_seed(self):
+        """Tests that running with the same seed yields the same results,
+        while running with a different seed yields different results.
+        """
+        sampler = self._create_sampler(self.seed)
+        same_seed = self._create_sampler(self.seed)
+        # we'll start the different seed from the same start position; this
+        # should still yield different positions after several iterations
+        diff_seed = self._create_sampler()
+        # not passing a seed should result in a different seed; check that
+        self.assertNotEqual(sampler.seed, diff_seed.seed,
+                            "Creating a random seed gave the same result as "
+                            "a {} (the odds of this happening should be very "
+                            "small)".format(self.seed))
+        sampler.run(self.iterint)
+        same_seed.run(self.iterint)
+        diff_seed.run(self.iterint)
+        # check that the same seed gives the same result
+        comp = _compare_dict_array(sampler.current_positions,
+                                   same_seed.current_positions)
+        self.assertTrue(comp,
+                        "Using the same seed and start did not give the "
+                        "same positions")
+        comp = _compare_dict_array(sampler.current_stats,
+                                   same_seed.current_stats)
+        self.assertTrue(comp,
+                        "Using the same seed and start did not give the "
+                        "same stats")
+        if self.model.blob_params:
+            comp = _compare_dict_array(sampler.current_blobs,
+                                       same_seed.current_blobs)
+            self.assertTrue(comp,
+                            "Using the same seed and start did not give the "
+                            "same blobs")
+        # check that different seeds give different results
+        comp = _compare_dict_array(sampler.current_positions,
+                                   diff_seed.current_positions)
+        self.assertFalse(comp,
+                         "Using the same seed and start did not give the "
+                         "same positions")
+        comp = _compare_dict_array(sampler.current_stats,
+                                   diff_seed.current_stats)
+        self.assertFalse(comp,
+                         "Using the same seed and start did not give the "
+                         "same stats")
+        if self.model.blob_params:
+            comp = _compare_dict_array(sampler.current_blobs,
+                                       diff_seed.current_blobs)
+            self.assertFalse(comp,
+                             "Using the same seed and start did not give "
+                             "the same blobs")
+
+    def test_clear_memory(self):
+        """Tests that clearing memory and running yields the same result as if
+        the memory had not been cleared.
+        """
+        sampler = self._create_sampler(self.seed)
+        sampler2 = self._create_sampler(self.seed)
+        # run both for a few iterations
+        sampler.run(self.iterint)
+        sampler2.run(self.iterint)
+        # clear one, but don't clear the other
+        sampler.clear()
+        # now run both for a few more iterations
+        sampler.run(self.iterint)
+        sampler2.run(self.iterint)
+        # they should be in the same place
+        comp = _compare_dict_array(sampler.current_positions,
+                                   sampler2.current_positions)
+        self.assertTrue(comp,
+                        "Clearing memory did not yield the same positions "
+                        "as if the memory had not been cleared")
+        comp = _compare_dict_array(sampler.current_stats,
+                                   sampler2.current_stats)
+        self.assertTrue(comp,
+                        "Clearing memory did not yield the same stats "
+                        "as if the memory had not been cleared")
+        if self.model.blob_params:
+            comp = _compare_dict_array(sampler.current_blobs,
+                                       sampler2.current_blobs)
+            self.assertTrue(comp,
+                            "Clearing memory did not yield the same blobs "
+                            "as if the memory had not been cleared")
+
+
+class TestMHSamplerMultiProc(TestMHSampler):
+    """Repeats the MH sampler tests in a multiprocessing environment."""
+    nprocs = 4
+
+
+class TestMHSamplerWithBlobs(TestMHSampler):
+    """Repeats the MH sampler tests with a model that returns blobs."""
+    model_cls = ModelWithBlobs
+
+
+class TestMHSamplerWithBlobsMultiProc(TestMHSampler):
+    """Repeats the MH sampler tests with a model that returns blobs
+    in a multiprocessing environment."""
+    model_cls = ModelWithBlobs
+    nprocs = 4
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_mhsampler.py
+++ b/test/test_mhsampler.py
@@ -157,7 +157,7 @@ def test_seed(model_cls, nprocs):
     """
     model = model_cls()
     sampler = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED)
-    # now create a nother sampler with the same seed and starting position
+    # now create another sampler with the same seed and starting position
     same_seed = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED,
                                 set_start=False)
     same_seed.start_position = sampler.start_position

--- a/test/test_mhsampler.py
+++ b/test/test_mhsampler.py
@@ -2,9 +2,9 @@
 
 from __future__ import (print_function, absolute_import)
 
-import unittest
 import itertools
 import multiprocessing
+import pytest
 import numpy
 import randomgen
 import epsie
@@ -12,313 +12,232 @@ from epsie.samplers import MetropolisHastingsSampler
 from _utils import (Model, ModelWithBlobs)
 
 
+NCHAINS = 8
+ITERINT = 32
+SEED = 11001001
+
+def _create_sampler(model, nprocs, nchains=None, seed=None, set_start=True):
+    """Creates a sampler."""
+    if nchains is None:
+        nchains = NCHAINS
+    if nprocs == 1:
+        pool = None
+    else:
+        pool = multiprocessing.Pool(nprocs)
+    sampler = MetropolisHastingsSampler(model.params, model,
+                                        nchains, pool=pool,
+                                        seed=seed)
+    if set_start:
+        sampler.start_position = model.prior_rvs(size=nchains)
+    return sampler
+
+
+def _check_array(array, expected_params, expected_shape):
+    """Helper function to test arrays returned by the sampler."""
+    # check that the fields are the same as the model's
+    assert sorted(array.dtype.names) == sorted(expected_params)
+    # check that the shape is what's expected
+    assert array.shape == expected_shape
+    # check that we can turn this into a dictionary
+    adict = epsie.array2dict(array)
+    assert sorted(adict.keys()) == sorted(expected_params)
+    for param, val in adict.items():
+        assert val.shape == expected_shape
+
+
 def _compare_dict_array(a, b):
     """Helper function to test if two dictionaries of arrays are the
     same.
     """
     # first check that keys are the same
-    if a.keys() != b.keys():
-        return False
-    return all([(a[p] == b[p]).all() for p in a])
-
-class TestMHSampler(unittest.TestCase):
-    """Runs the MHSampler and runs various tests on it."""
-    nchains = 8
-    nprocs = 1
-    iterint = 32  # standard number of iterations we'll run for
-    seed = 11001001
-    model_cls = Model
-
-    def setUp(self):
-        self.model = self.model_cls()
-        if self.nprocs == 1:
-            self.pool = None
-        else:
-            self.pool = multiprocessing.Pool(self.nprocs)
-        self.start_position = self.model.prior_rvs(size=self.nchains)
-
-    def _create_sampler(self, seed=None, set_start=True):
-        """Creates a sampler."""
-        sampler = MetropolisHastingsSampler(self.model.params, self.model,
-                                            self.nchains, pool=self.pool,
-                                            seed=seed)
-        if set_start:
-            sampler.start_position = self.start_position
-        return sampler
-
-    def _check_array(self, array, expected_params, expected_shape):
-        """Helper function to test arrays returned by the sampler."""
-        # check that the fields are the same as the model's
-        self.assertEqual(sorted(array.dtype.names),
-                         sorted(expected_params),
-                         "Sampler's returned parameters differ from the "
-                         "expected")
-        # check that the shape is what's expected
-        self.assertEqual(array.shape, expected_shape,
-                         "Array does not have the expected shape "
-                         "(expected {},  got {})".format(expected_shape,
-                                                         array.shape))
-        # check that we can turn this into a dictionary
-        adict = epsie.array2dict(array)
-        self.assertEqual(sorted(adict.keys()), sorted(expected_params),
-                         "Not all parameters converted to dictionary")
-        for param, val in adict.items():
-            self.assertEqual(val.shape, expected_shape,
-                             "Dictionary values do not have expected shape "
-                             "(expected {}; got {})".format(expected_shape,
-                                                            val.shape))
-
-    def test_chains(self):
-        """Sets up and runs a sampler for a few iterations, then performs
-        the following checks:
-
-        * That the positions, stats, acceptance ratios, and (if the model
-          returns blobs) blobs all have the expected parameters, shape
-          nchains x niterations, and can be converted to dictionaries of
-          arrays.
-        * That the ``current_(positions|stats|blobs)`` (if the model returns
-          blobs) are the same as the last item in the positions/stats/blobs.
-        * If the model does not return blobs, that the ``blobs`` and
-          ``current_blobs`` are all None.
-        * That the chains all have different random states after the
-          iterations, and different positions/stats/blobs.
-        """
-        sampler = self._create_sampler(self.seed)
-        sampler.run(self.iterint)
-        # check that we get the positions back in the expected format
-        positions = sampler.positions
-        expected_shape = (self.nchains, self.iterint)
-        self._check_array(positions, self.model.params,
-                          expected_shape)
-        # check that the current position is the same as the last in the array
-        comp = _compare_dict_array(epsie.array2dict(positions[..., -1]),
-                                   sampler.current_positions)
-        self.assertTrue(comp,
-                        "Last values in position array are not the same "
-                        "as the current_positions attribute")
-        # check that the stats have the expected fields and shape
-        stats = sampler.stats
-        self._check_array(stats, ['logl', 'logp'],
-                          expected_shape)
-        # check that the current position is the same as the last in the array
-        comp = _compare_dict_array(epsie.array2dict(stats[..., -1]),
-                                   sampler.current_stats)
-        self.assertTrue(comp,
-                        "Last values in stats array are not the same "
-                        "as the current_stats attribute")
-        # check that the acceptance ratios have the expected fields and shape
-        acceptance = sampler.acceptance
-        self._check_array(acceptance, ['acceptance_ratio', 'accepted'],
-                          expected_shape)
-        # check the individual chains
-        for ii, chain in enumerate(sampler.chains):
-            # check that the length matches the number of iterations
-            self.assertEqual(len(chain), self.iterint,
-                             "Length of chain {} is different than the number "
-                             "of iterations".format(ii))
-            # check that hasblobs is None if the model doesn't return any
-            if not self.model.blob_params:
-                self.assertFalse(chain.hasblobs,
-                                 "chain.hasblobs should be false if the model "
-                                 "does not return blobs")
-            else:
-                self.assertTrue(chain.hasblobs,
-                                "chain.hasblobs should be true if the model "
-                                "returns blobs")
-        # check the blobs
-        blobs = sampler.blobs
-        current_blobs = sampler.current_blobs
-        if self.model.blob_params:
-            self._check_array(blobs, self.model.blob_params,
-                              expected_shape)
-            comp = _compare_dict_array(epsie.array2dict(blobs[..., -1]),
-                                       current_blobs)
-            self.assertTrue(comp,
-                            "Last values in the blobs array are not the "
-                            "same as the current_blobs attribute")
-        else:
-            # check that blobs are None since this model doesn't have blobs
-            self.assertTrue(blobs is None,
-                            "Sampler should return None as the blob attribute "
-                            "when the model does not return blobs")
-            self.assertTrue(current_blobs is None,
-                            "current_blobs should be None since the model "
-                            "does not return blobs")
-        # check that each chain's random state and current values are different
-        combos = itertools.combinations(range(len(sampler.chains)), 2)
-        for ii, jj in combos:
-            chain = sampler.chains[ii]
-            other = sampler.chains[jj]
-            rstate = chain.state['proposal_dist']['random_state']
-            ostate = other.state['proposal_dist']['random_state']
-            self.assertNotEqual(rstate, ostate,
-                                "Chains should all have different "
-                                "random states")
-            comp = _compare_dict_array(chain.current_position,
-                                       other.current_position)
-            self.assertFalse(comp,
-                             "Chains should all have different current "
-                             "positions")
-            comp = _compare_dict_array(chain.current_stats,
-                                       other.current_stats)
-            self.assertFalse(comp,
-                             "Chains should all have different current "
-                             "positions")
-            if self.model.blob_params:
-                # note: we're checking that the blobs aren't the same, but
-                # it might happen for a model that they would be the same
-                # across chains, depending on the data. The testing models
-                # in utils.py return the value of the log likelihood in
-                # each parameter for the blobs, so we expect them to be
-                # different in this case
-                comp = _compare_dict_array(chain.current_blob,
-                                           other.current_blob)
-                self.assertFalse(comp,
-                                 "Chains should all have different blobs "
-                                 "since the tested model returns blob "
-                                 "values that depend on the position")
+    assert list(a.keys()) == list(b.keys())
+    # now check the values
+    assert all([(a[p] == b[p]).all() for p in a])
 
 
-    def test_checkpointing(self):
-        """Tests that resuming from checkpoint yields the same result as if
-        no checkpoint happened.
-        """
+def _anticompare_dict_array(a, b):
+    """Helper function to test if two dictionaries of arrays are the
+    not the same.
+    """
+    # first check that keys are the same
+    assert list(a.keys()) == list(b.keys())
+    # now check the values
+    assert not all([(a[p] == b[p]).all() for p in a])
+
+
+@pytest.mark.parametrize('model_cls', [Model, ModelWithBlobs])
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_chains(model_cls, nprocs):
+    """Sets up and runs a sampler for a few iterations, then performs
+    the following checks:
+
+    * That the positions, stats, acceptance ratios, and (if the model
+      returns blobs) blobs all have the expected parameters, shape
+      nchains x niterations, and can be converted to dictionaries of
+      arrays.
+    * That the ``current_(positions|stats|blobs)`` (if the model returns
+      blobs) are the same as the last item in the positions/stats/blobs.
+    * If the model does not return blobs, that the ``blobs`` and
+      ``current_blobs`` are all None.
+    * That the chains all have different random states after the
+      iterations, and different positions/stats/blobs.
+    """
+    model = model_cls()
+    sampler = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED)
+    sampler.run(ITERINT)
+    # check that we get the positions back in the expected format
+    positions = sampler.positions
+    expected_shape = (NCHAINS, ITERINT)
+    _check_array(positions, model.params,
+                      expected_shape)
+    # check that the current position is the same as the last in the array
+    _compare_dict_array(epsie.array2dict(positions[..., -1]),
+                        sampler.current_positions)
+    # check that the stats have the expected fields and shape
+    stats = sampler.stats
+    _check_array(stats, ['logl', 'logp'],
+                 expected_shape)
+    # check that the current position is the same as the last in the array
+    _compare_dict_array(epsie.array2dict(stats[..., -1]),
+                        sampler.current_stats)
+    # check that the acceptance ratios have the expected fields and shape
+    acceptance = sampler.acceptance
+    _check_array(acceptance, ['acceptance_ratio', 'accepted'],
+                 expected_shape)
+    # check the individual chains
+    for ii, chain in enumerate(sampler.chains):
+        # check that the length matches the number of iterations
+        assert len(chain) == ITERINT
+        # check that hasblobs is None if the model doesn't return any
+        assert chain.hasblobs == bool(model.blob_params)
+    # check the blobs
+    blobs = sampler.blobs
+    current_blobs = sampler.current_blobs
+    if model.blob_params:
+        _check_array(blobs, model.blob_params, expected_shape)
+        _compare_dict_array(epsie.array2dict(blobs[..., -1]),
+                            current_blobs)
+    else:
+        # check that blobs are None since this model doesn't have blobs
+        assert blobs is None
+        assert current_blobs is None
+    # check that each chain's random state and current values are different
+    combos = itertools.combinations(range(len(sampler.chains)), 2)
+    for ii, jj in combos:
+        chain = sampler.chains[ii]
+        other = sampler.chains[jj]
+        rstate = chain.state['proposal_dist']['random_state']
+        ostate = other.state['proposal_dist']['random_state']
+        assert rstate != ostate
+        _anticompare_dict_array(chain.current_position,
+                                other.current_position)
+        _anticompare_dict_array(chain.current_stats,
+                                other.current_stats)
+        if model.blob_params:
+            # note: we're checking that the blobs aren't the same, but
+            # it might happen for a model that they would be the same
+            # across chains, depending on the data. The testing models
+            # in utils.py return the value of the log likelihood in
+            # each parameter for the blobs, so we expect them to be
+            # different in this case
+            _anticompare_dict_array(chain.current_blob,
+                                    other.current_blob)
+
+
+@pytest.mark.parametrize('model_cls', [Model, ModelWithBlobs])
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_checkpointing(model_cls, nprocs):
+    """Tests that resuming from checkpoint yields the same result as if
+    no checkpoint happened.
+
+    This test requires h5py to be installed.
+    """
+    try:
         import h5py
-        sampler = self._create_sampler(self.seed)
-        # create a second sampler for comparison; we won't bother setting
-        # a seed or start position, since that shouldn't matter when loading
-        # from a checkpoint
-        sampler2 = self._create_sampler(set_start=False)
-        sampler.run(self.iterint)
-        # checkpoint to an h5py file in memory
-        fp = h5py.File('test.hdf', 'w', driver='core', backing_store=False)
-        sampler.checkpoint(fp)
-        # run for another set of iterations
-        sampler.run(self.iterint)
-        # set the other sampler's state using the checkpiont
-        sampler2.set_state_from_checkpoint(fp)
-        fp.close()
-        # run again
-        sampler2.run(self.iterint)
-        # compare the two
-        comp = _compare_dict_array(sampler.current_positions,
-                                   sampler2.current_positions)
-        self.assertTrue(comp,
-                        "Resuming from checkpoint did not yield the same "
-                        "positions as running continously")
-        comp = _compare_dict_array(sampler.current_stats,
-                                   sampler2.current_stats)
-        self.assertTrue(comp,
-                        "Resuming from checkpoint did not yield the same "
-                        "stats as running continously")
-        if self.model.blob_params:
-            comp = _compare_dict_array(sampler.current_blobs,
-                                       sampler2.current_blobs)
-            self.assertTrue(comp,
-                            "Resuming from checkpoint did not yield the same "
-                            "blobs as running continously")
-
-    def test_seed(self):
-        """Tests that running with the same seed yields the same results,
-        while running with a different seed yields different results.
-        """
-        sampler = self._create_sampler(self.seed)
-        same_seed = self._create_sampler(self.seed)
-        # we'll start the different seed from the same start position; this
-        # should still yield different positions after several iterations
-        diff_seed = self._create_sampler()
-        # not passing a seed should result in a different seed; check that
-        self.assertNotEqual(sampler.seed, diff_seed.seed,
-                            "Creating a random seed gave the same result as "
-                            "a {} (the odds of this happening should be very "
-                            "small)".format(self.seed))
-        sampler.run(self.iterint)
-        same_seed.run(self.iterint)
-        diff_seed.run(self.iterint)
-        # check that the same seed gives the same result
-        comp = _compare_dict_array(sampler.current_positions,
-                                   same_seed.current_positions)
-        self.assertTrue(comp,
-                        "Using the same seed and start did not give the "
-                        "same positions")
-        comp = _compare_dict_array(sampler.current_stats,
-                                   same_seed.current_stats)
-        self.assertTrue(comp,
-                        "Using the same seed and start did not give the "
-                        "same stats")
-        if self.model.blob_params:
-            comp = _compare_dict_array(sampler.current_blobs,
-                                       same_seed.current_blobs)
-            self.assertTrue(comp,
-                            "Using the same seed and start did not give the "
-                            "same blobs")
-        # check that different seeds give different results
-        comp = _compare_dict_array(sampler.current_positions,
-                                   diff_seed.current_positions)
-        self.assertFalse(comp,
-                         "Using the same seed and start did not give the "
-                         "same positions")
-        comp = _compare_dict_array(sampler.current_stats,
-                                   diff_seed.current_stats)
-        self.assertFalse(comp,
-                         "Using the same seed and start did not give the "
-                         "same stats")
-        if self.model.blob_params:
-            comp = _compare_dict_array(sampler.current_blobs,
-                                       diff_seed.current_blobs)
-            self.assertFalse(comp,
-                             "Using the same seed and start did not give "
-                             "the same blobs")
-
-    def test_clear_memory(self):
-        """Tests that clearing memory and running yields the same result as if
-        the memory had not been cleared.
-        """
-        sampler = self._create_sampler(self.seed)
-        sampler2 = self._create_sampler(self.seed)
-        # run both for a few iterations
-        sampler.run(self.iterint)
-        sampler2.run(self.iterint)
-        # clear one, but don't clear the other
-        sampler.clear()
-        # now run both for a few more iterations
-        sampler.run(self.iterint)
-        sampler2.run(self.iterint)
-        # they should be in the same place
-        comp = _compare_dict_array(sampler.current_positions,
-                                   sampler2.current_positions)
-        self.assertTrue(comp,
-                        "Clearing memory did not yield the same positions "
-                        "as if the memory had not been cleared")
-        comp = _compare_dict_array(sampler.current_stats,
-                                   sampler2.current_stats)
-        self.assertTrue(comp,
-                        "Clearing memory did not yield the same stats "
-                        "as if the memory had not been cleared")
-        if self.model.blob_params:
-            comp = _compare_dict_array(sampler.current_blobs,
-                                       sampler2.current_blobs)
-            self.assertTrue(comp,
-                            "Clearing memory did not yield the same blobs "
-                            "as if the memory had not been cleared")
+    except ImportError:
+        raise ImportError("h5py must be installed to run this test")
+    model = model_cls()
+    sampler = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED)
+    # create a second sampler for comparison; we won't bother setting
+    # a seed or start position, since that shouldn't matter when loading
+    # from a checkpoint
+    sampler2 = _create_sampler(model, nprocs, nchains=NCHAINS, seed=None,
+                               set_start=False)
+    sampler.run(ITERINT)
+    # checkpoint to an h5py file in memory
+    fp = h5py.File('test.hdf', 'w', driver='core', backing_store=False)
+    sampler.checkpoint(fp)
+    # run for another set of iterations
+    sampler.run(ITERINT)
+    # set the other sampler's state using the checkpoint
+    sampler2.set_state_from_checkpoint(fp)
+    fp.close()
+    # run again
+    sampler2.run(ITERINT)
+    # compare the two
+    _compare_dict_array(sampler.current_positions, sampler2.current_positions)
+    _compare_dict_array(sampler.current_stats, sampler2.current_stats)
+    if model.blob_params:
+        _compare_dict_array(sampler.current_blobs, sampler2.current_blobs)
 
 
-class TestMHSamplerMultiProc(TestMHSampler):
-    """Repeats the MH sampler tests in a multiprocessing environment."""
-    nprocs = 4
+@pytest.mark.parametrize('model_cls', [Model, ModelWithBlobs])
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_seed(model_cls, nprocs):
+    """Tests that running with the same seed yields the same results,
+    while running with a different seed yields different results.
+    """
+    model = model_cls()
+    sampler = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED)
+    # now create a nother sampler with the same seed and starting position
+    same_seed = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED,
+                                set_start=False)
+    same_seed.start_position = sampler.start_position
+    # we'll start the different seed from the same start position; this
+    # should still yield different positions after several iterations
+    diff_seed = _create_sampler(model, nprocs, nchains=NCHAINS, seed=None,
+                                set_start=False)
+    diff_seed.start_position = sampler.start_position
+    # not passing a seed should result in a different seed; check that
+    assert sampler.seed != diff_seed.seed
+    sampler.run(ITERINT)
+    same_seed.run(ITERINT)
+    diff_seed.run(ITERINT)
+    # check that the same seed gives the same result
+    _compare_dict_array(sampler.current_positions, same_seed.current_positions)
+    _compare_dict_array(sampler.current_stats, same_seed.current_stats)
+    if model.blob_params:
+        _compare_dict_array(sampler.current_blobs, same_seed.current_blobs)
+    # check that different seeds give different results
+    _anticompare_dict_array(sampler.current_positions,
+                            diff_seed.current_positions)
+    _anticompare_dict_array(sampler.current_stats, diff_seed.current_stats)
+    if model.blob_params:
+        _anticompare_dict_array(sampler.current_blobs,
+                                diff_seed.current_blobs)
 
 
-class TestMHSamplerWithBlobs(TestMHSampler):
-    """Repeats the MH sampler tests with a model that returns blobs."""
-    model_cls = ModelWithBlobs
-
-
-class TestMHSamplerWithBlobsMultiProc(TestMHSampler):
-    """Repeats the MH sampler tests with a model that returns blobs
-    in a multiprocessing environment."""
-    model_cls = ModelWithBlobs
-    nprocs = 4
-
-
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize('model_cls', [Model, ModelWithBlobs])
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_clear_memory(model_cls, nprocs):
+    """Tests that clearing memory and running yields the same result as if
+    the memory had not been cleared.
+    """
+    model = model_cls()
+    sampler = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED)
+    sampler2 = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED,
+                               set_start=False)
+    sampler2.start_position = sampler.start_position
+    # run both for a few iterations
+    sampler.run(ITERINT)
+    sampler2.run(ITERINT)
+    # clear one, but don't clear the other
+    sampler.clear()
+    # now run both for a few more iterations
+    sampler.run(ITERINT)
+    sampler2.run(ITERINT)
+    # they should be in the same place
+    _compare_dict_array(sampler.current_positions, sampler2.current_positions)
+    _compare_dict_array(sampler.current_stats, sampler2.current_stats)
+    if model.blob_params:
+        _compare_dict_array(sampler.current_blobs, sampler2.current_blobs)

--- a/test/test_mhsampler.py
+++ b/test/test_mhsampler.py
@@ -103,9 +103,9 @@ class TestMHSampler(unittest.TestCase):
         # check that the current position is the same as the last in the array
         comp = _compare_dict_array(epsie.array2dict(stats[..., -1]),
                                    sampler.current_stats)
-        self.assertEqual(comp,
-                         "Last values in stats array are not the same "
-                         "as the current_stats attribute")
+        self.assertTrue(comp,
+                        "Last values in stats array are not the same "
+                        "as the current_stats attribute")
         # check that the acceptance ratios have the expected fields and shape
         acceptance = sampler.acceptance
         self._check_array(acceptance, ['acceptance_ratio', 'accepted'],
@@ -145,7 +145,7 @@ class TestMHSampler(unittest.TestCase):
                             "current_blobs should be None since the model "
                             "does not return blobs")
         # check that each chain's random state and current values are different
-        combos = itertools.combinations(len(sampler.chains), 2)
+        combos = itertools.combinations(range(len(sampler.chains)), 2)
         for ii, jj in combos:
             chain = sampler.chains[ii]
             other = sampler.chains[jj]
@@ -154,8 +154,8 @@ class TestMHSampler(unittest.TestCase):
             self.assertNotEqual(rstate, ostate,
                                 "Chains should all have different "
                                 "random states")
-            comp = _compare_dict_array(chain.current_positions,
-                                       other.current_positions)
+            comp = _compare_dict_array(chain.current_position,
+                                       other.current_position)
             self.assertFalse(comp,
                              "Chains should all have different current "
                              "positions")
@@ -171,8 +171,8 @@ class TestMHSampler(unittest.TestCase):
                 # in utils.py return the value of the log likelihood in
                 # each parameter for the blobs, so we expect them to be
                 # different in this case
-                comp = _compare_dict_array(chain.current_blobs,
-                                           other.current_blobs)
+                comp = _compare_dict_array(chain.current_blob,
+                                           other.current_blob)
                 self.assertFalse(comp,
                                  "Chains should all have different blobs "
                                  "since the tested model returns blob "

--- a/test/test_mhsampler.py
+++ b/test/test_mhsampler.py
@@ -25,7 +25,7 @@ import numpy
 import epsie
 from epsie.samplers import MetropolisHastingsSampler
 from _utils import (Model, ModelWithBlobs, _check_array, _compare_dict_array,
-                    _anticompare_dict_array)
+                    _anticompare_dict_array, _check_chains_are_different)
 
 
 NCHAINS = 8
@@ -108,24 +108,8 @@ def test_chains(model_cls, nprocs):
     # check that each chain's random state and current values are different
     combos = itertools.combinations(range(len(sampler.chains)), 2)
     for ii, jj in combos:
-        chain = sampler.chains[ii]
-        other = sampler.chains[jj]
-        rstate = chain.state['proposal_dist']['random_state']
-        ostate = other.state['proposal_dist']['random_state']
-        assert rstate != ostate
-        _anticompare_dict_array(chain.current_position,
-                                other.current_position)
-        _anticompare_dict_array(chain.current_stats,
-                                other.current_stats)
-        if model.blob_params:
-            # note: we're checking that the blobs aren't the same, but
-            # it might happen for a model that they would be the same
-            # across chains, depending on the data. The testing models
-            # in utils.py return the value of the log likelihood in
-            # each parameter for the blobs, so we expect them to be
-            # different in this case
-            _anticompare_dict_array(chain.current_blob,
-                                    other.current_blob)
+        _check_chains_are_different(sampler.chains[ii], sampler.chains[jj],
+                                    test_blobs=bool(model.blob_params))
 
 
 @pytest.mark.parametrize('model_cls', [Model, ModelWithBlobs])

--- a/test/test_ptsampler.py
+++ b/test/test_ptsampler.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2020  Collin Capano
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""Performs unit tests on the ParallelTempered sampler."""
+
+from __future__ import (print_function, absolute_import)
+
+import itertools
+import multiprocessing
+import pytest
+import numpy
+import epsie
+from epsie import make_betas_ladder
+from epsie.samplers import ParallelTemperedSampler
+from _utils import (Model, ModelWithBlobs, _check_array, _compare_dict_array,
+                    _anticompare_dict_array, _check_chains_are_different)
+
+
+NCHAINS = 4
+NTEMPS = 3
+BETAS = make_betas_ladder(NTEMPS, 1e5)
+ITERINT = 32
+SEED = 2020
+
+
+def _create_sampler(model, nprocs, nchains=None, betas=None, swap_interval=1,
+                    seed=None, set_start=True):
+    """Creates a sampler."""
+    if nchains is None:
+        nchains = NCHAINS
+    if betas is None:
+        betas = BETAS
+    ntemps = len(betas)
+    if nprocs == 1:
+        pool = None
+    else:
+        pool = multiprocessing.Pool(nprocs)
+    sampler = ParallelTemperedSampler(model.params, model, nchains,
+                                      betas=betas, seed=seed,
+                                      swap_interval=swap_interval,
+                                      pool=pool)
+    if set_start:
+        sampler.start_position = model.prior_rvs(size=nchains*ntemps,
+                                                 shape=(ntemps, nchains))
+    return sampler
+
+
+@pytest.mark.parametrize('model_cls', [Model, ModelWithBlobs])
+@pytest.mark.parametrize('nprocs', [1, 4])
+@pytest.mark.parametrize('swap_interval', [1, 3])
+def test_chains(model_cls, nprocs, swap_interval):
+    """Sets up and runs a sampler for a few iterations, then performs
+    the following checks:
+
+    * That the positions, stats, acceptance ratios, and (if the model
+      returns blobs) blobs all have the expected parameters, shape
+      ntemps x nchains x niterations, and can be converted to dictionaries of
+      arrays.
+    * That the ``current_(positions|stats|blobs)`` (if the model returns
+      blobs) are the same as the last item in the positions/stats/blobs.
+    * If the model does not return blobs, that the ``blobs`` and
+      ``current_blobs`` are all None.
+    * That the chains all have different random states after the
+      iterations, and different positions/stats/blobs.
+    """
+    model = model_cls()
+    sampler = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED,
+                              swap_interval=swap_interval)
+    sampler.run(ITERINT)
+    # check that the number of recorded iterations matches how long we
+    # actually ran for
+    assert sampler.niterations == ITERINT
+    # check that we get the positions back in the expected format
+    positions = sampler.positions
+    expected_shape = (NTEMPS, NCHAINS, ITERINT)
+    _check_array(positions, model.params, expected_shape)
+    # check that the current positions have the right shape
+    for arr in sampler.start_position.values():
+        assert arr.shape == (NTEMPS, NCHAINS)
+    for arr in sampler.current_positions.values():
+        assert arr.shape == (NTEMPS, NCHAINS)
+    for arr in sampler.current_stats.values():
+        assert arr.shape == (NTEMPS, NCHAINS)
+    if model.blob_params:
+        for arr in sampler.current_blobs.values():
+            assert arr.shape == (NTEMPS, NCHAINS)
+    # check that the current position is the same as the last in the array
+    _compare_dict_array(epsie.array2dict(positions[..., -1]),
+                        sampler.current_positions)
+    # check that the stats have the expected fields and shape
+    stats = sampler.stats
+    _check_array(stats, ['logl', 'logp'], expected_shape)
+    # check that the current position is the same as the last in the array
+    _compare_dict_array(epsie.array2dict(stats[..., -1]),
+                        sampler.current_stats)
+    # check that the acceptance ratios have the expected fields and shape
+    acceptance = sampler.acceptance
+    _check_array(acceptance, ['acceptance_ratio', 'accepted'], expected_shape)
+    # check that the temperature swaps have the expected shape
+    temperature_swaps = sampler.temperature_swaps
+    assert temperature_swaps.shape == (NTEMPS, NCHAINS, ITERINT//swap_interval) 
+    # ditto for the temperature acceptance
+    temperature_acceptance = sampler.temperature_acceptance
+    assert temperature_acceptance.shape == (NTEMPS-1, NCHAINS,
+                                            ITERINT//swap_interval)
+    # check the individual chains
+    for ii, chain in enumerate(sampler.chains):
+        # check that the length matches the number of iterations
+        assert len(chain) == ITERINT
+        # check that hasblobs is None if the model doesn't return any
+        assert chain.hasblobs == bool(model.blob_params)
+        # do the same for every temperature
+        for kk, subchain in enumerate(chain.chains):
+            # check that the length matches the number of iterations
+            assert len(subchain) == ITERINT
+            # check that hasblobs is None if the model doesn't return any
+            assert subchain.hasblobs == bool(model.blob_params)
+    # check the blobs
+    blobs = sampler.blobs
+    current_blobs = sampler.current_blobs
+    if model.blob_params:
+        _check_array(blobs, model.blob_params, expected_shape)
+        _compare_dict_array(epsie.array2dict(blobs[..., -1]),
+                            current_blobs)
+    else:
+        # check that blobs are None since this model doesn't have blobs
+        assert blobs is None
+        assert current_blobs is None
+    # check that every temperature in every chain has a different random state
+    # and different current values than all others
+    combos = itertools.combinations(range(len(sampler.chains)), 2)
+    temp_combos = itertools.combinations(range(NTEMPS), 2)
+    # check that all temps have different current positions/stats/blobs within
+    # each chain, but that they all have the same random state
+    for chain in sampler.chains:
+        for kk, ll in temp_combos:
+            _check_chains_are_different(chain.chains[kk], chain.chains[ll],
+                                        test_blobs=bool(model.blob_params),
+                                        test_state=False)
+            rstate = chain.chains[kk].state['proposal_dist']['random_state']
+            ostate = chain.chains[ll].state['proposal_dist']['random_state']
+            assert rstate == ostate
+    # now check that all temps in different chains are different
+    for ii, jj in combos:
+        chain = sampler.chains[ii]
+        other = sampler.chains[jj]
+        for kk in range(NTEMPS):
+            for ll in range(NTEMPS):
+                _check_chains_are_different(chain.chains[kk], other.chains[ll],
+                                            test_blobs=bool(model.blob_params))
+
+
+
+@pytest.mark.parametrize('model_cls', [Model, ModelWithBlobs])
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_checkpointing(model_cls, nprocs):
+    """Tests that resuming from checkpoint yields the same result as if
+    no checkpoint happened.
+
+    This test requires h5py to be installed.
+    """
+    try:
+        import h5py
+    except ImportError:
+        raise ImportError("h5py must be installed to run this test")
+    model = model_cls()
+    sampler = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED)
+    # create a second sampler for comparison; we won't bother setting
+    # a seed or start position, since that shouldn't matter when loading
+    # from a checkpoint
+    sampler2 = _create_sampler(model, nprocs, nchains=NCHAINS, seed=None,
+                               set_start=False)
+    sampler.run(ITERINT)
+    # checkpoint to an h5py file in memory
+    fp = h5py.File('test.hdf', 'w', driver='core', backing_store=False)
+    sampler.checkpoint(fp)
+    # run for another set of iterations
+    sampler.run(ITERINT)
+    # set the other sampler's state using the checkpoint
+    sampler2.set_state_from_checkpoint(fp)
+    fp.close()
+    # run again
+    sampler2.run(ITERINT)
+    # compare the two
+    _compare_dict_array(sampler.current_positions, sampler2.current_positions)
+    _compare_dict_array(sampler.current_stats, sampler2.current_stats)
+    if model.blob_params:
+        _compare_dict_array(sampler.current_blobs, sampler2.current_blobs)
+
+
+@pytest.mark.parametrize('model_cls', [Model, ModelWithBlobs])
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_seed(model_cls, nprocs):
+    """Tests that running with the same seed yields the same results,
+    while running with a different seed yields different results.
+    """
+    model = model_cls()
+    sampler = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED)
+    # now create another sampler with the same seed and starting position
+    same_seed = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED,
+                                set_start=False)
+    same_seed.start_position = sampler.start_position
+    assert sampler.seed == same_seed.seed
+    _compare_dict_array(sampler.start_position, same_seed.start_position)
+    # we'll start the different seed from the same start position; this
+    # should still yield different positions after several iterations
+    diff_seed = _create_sampler(model, nprocs, nchains=NCHAINS, seed=None,
+                                set_start=False)
+    diff_seed.start_position = sampler.start_position
+    # not passing a seed should result in a different seed; check that
+    assert sampler.seed != diff_seed.seed
+    sampler.run(ITERINT)
+    same_seed.run(ITERINT)
+    diff_seed.run(ITERINT)
+    # check that the same seed gives the same result
+    _compare_dict_array(sampler.current_positions, same_seed.current_positions)
+    _compare_dict_array(sampler.current_stats, same_seed.current_stats)
+    if model.blob_params:
+        _compare_dict_array(sampler.current_blobs, same_seed.current_blobs)
+    # check that different seeds give different results
+    _anticompare_dict_array(sampler.current_positions,
+                            diff_seed.current_positions)
+    _anticompare_dict_array(sampler.current_stats, diff_seed.current_stats)
+    if model.blob_params:
+        _anticompare_dict_array(sampler.current_blobs,
+                                diff_seed.current_blobs)
+
+
+@pytest.mark.parametrize('model_cls', [Model, ModelWithBlobs])
+@pytest.mark.parametrize('nprocs', [1, 4])
+@pytest.mark.parametrize('swap_interval', [1, 3])
+def test_clear_memory(model_cls, nprocs, swap_interval):
+    """Tests that clearing memory and running yields the same result as if
+    the memory had not been cleared.
+    """
+    model = model_cls()
+    sampler = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED,
+                              swap_interval=swap_interval)
+    sampler2 = _create_sampler(model, nprocs, nchains=NCHAINS, seed=SEED,
+                               swap_interval=swap_interval, set_start=False)
+    sampler2.start_position = sampler.start_position
+    # run both for a few iterations
+    sampler.run(ITERINT)
+    sampler2.run(ITERINT)
+    # clear one, but don't clear the other
+    sampler.clear()
+    # now run both for a few more iterations
+    sampler.run(ITERINT)
+    sampler2.run(ITERINT)
+    # check that the number of recorded iterations matches how long we
+    # actually ran for
+    assert sampler.niterations == 2*ITERINT
+    assert sampler2.niterations == 2*ITERINT
+    # but that the lengths of the stored arrays differ
+    expected_shape = (NTEMPS, NCHAINS, ITERINT)
+    expected_shape2 = (NTEMPS, NCHAINS, 2*ITERINT)
+    _check_array(sampler.positions, model.params, expected_shape)
+    _check_array(sampler2.positions, model.params, expected_shape2)
+    _check_array(sampler.stats, ['logl', 'logp'], expected_shape)
+    _check_array(sampler2.stats, ['logl', 'logp'], expected_shape2)
+    _check_array(sampler.acceptance, ['acceptance_ratio', 'accepted'],
+                 expected_shape)
+    _check_array(sampler2.acceptance, ['acceptance_ratio', 'accepted'],
+                 expected_shape2)
+    if model.blob_params:
+        _check_array(sampler.blobs, model.blob_params, expected_shape)
+        _check_array(sampler2.blobs, model.blob_params, expected_shape2)
+    # check that the swaps have the expected shape
+    temperature_swaps = sampler.temperature_swaps
+    assert temperature_swaps.shape == (NTEMPS, NCHAINS, ITERINT//swap_interval) 
+    temperature_swaps = sampler2.temperature_swaps
+    assert temperature_swaps.shape == (NTEMPS, NCHAINS,
+                                       (2*ITERINT)//swap_interval) 
+    # ditto for the temperature acceptance
+    temperature_acceptance = sampler.temperature_acceptance
+    assert temperature_acceptance.shape == (NTEMPS-1, NCHAINS,
+                                            ITERINT//swap_interval)
+    temperature_acceptance = sampler2.temperature_acceptance
+    assert temperature_acceptance.shape == (NTEMPS-1, NCHAINS,
+                                            (2*ITERINT)//swap_interval)
+    # they should be in the same place
+    _compare_dict_array(sampler.current_positions, sampler2.current_positions)
+    _compare_dict_array(sampler.current_stats, sampler2.current_stats)
+    if model.blob_params:
+        _compare_dict_array(sampler.current_blobs, sampler2.current_blobs)

--- a/test/test_ptsampler.py
+++ b/test/test_ptsampler.py
@@ -113,7 +113,7 @@ def test_chains(model_cls, nprocs, swap_interval, proposals=None):
     _check_array(acceptance, ['acceptance_ratio', 'accepted'], expected_shape)
     # check that the temperature swaps have the expected shape
     temperature_swaps = sampler.temperature_swaps
-    assert temperature_swaps.shape == (NTEMPS, NCHAINS, ITERINT//swap_interval) 
+    assert temperature_swaps.shape == (NTEMPS, NCHAINS, ITERINT//swap_interval)
     # ditto for the temperature acceptance
     temperature_acceptance = sampler.temperature_acceptance
     assert temperature_acceptance.shape == (NTEMPS-1, NCHAINS,
@@ -163,7 +163,6 @@ def test_chains(model_cls, nprocs, swap_interval, proposals=None):
             for ll in range(NTEMPS):
                 _check_chains_are_different(chain.chains[kk], other.chains[ll],
                                             test_blobs=bool(model.blob_params))
-
 
 
 @pytest.mark.parametrize('model_cls', [Model, ModelWithBlobs])
@@ -285,10 +284,10 @@ def test_clear_memory(model_cls, nprocs, swap_interval, proposals=None):
         _check_array(sampler2.blobs, model.blob_params, expected_shape2)
     # check that the swaps have the expected shape
     temperature_swaps = sampler.temperature_swaps
-    assert temperature_swaps.shape == (NTEMPS, NCHAINS, ITERINT//swap_interval) 
+    assert temperature_swaps.shape == (NTEMPS, NCHAINS, ITERINT//swap_interval)
     temperature_swaps = sampler2.temperature_swaps
     assert temperature_swaps.shape == (NTEMPS, NCHAINS,
-                                       (2*ITERINT)//swap_interval) 
+                                       (2*ITERINT)//swap_interval)
     # ditto for the temperature acceptance
     temperature_acceptance = sampler.temperature_acceptance
     assert temperature_acceptance.shape == (NTEMPS-1, NCHAINS,


### PR DESCRIPTION
Adds a test directory with various unit tests using `pytest`. These should be carried out by Travis for each pull request.

Also fixes bug in the way the `ParallelTemperedSampler` was returning current positions/stats/blobs and the start position that was caught while adding these tests. It was supposed to return arrays with shape ntemps x nchains, but was returning nchains x ntemps instead.