### PR TITLE
Rename VeaAdaptive back to Adaptive

### DIFF
--- a/epsie/proposals/__init__.py
+++ b/epsie/proposals/__init__.py
@@ -18,32 +18,32 @@ from __future__ import absolute_import
 
 from .base import BaseProposal
 from .joint import JointProposal
-from .normal import (Normal, VeaAdaptiveNormal, SSAdaptiveNormal)
+from .normal import (Normal, AdaptiveNormal, SSAdaptiveNormal)
 # we'll also promote the Boundaries class to the top-level
 from .bounded_normal import (BoundedNormal, SSAdaptiveBoundedNormal,
-                             Boundaries, VeaAdaptiveBoundedNormal)
-from .angular import (Angular, SSAdaptiveAngular, VeaAdaptiveAngular)
+                             Boundaries, AdaptiveBoundedNormal)
+from .angular import (Angular, SSAdaptiveAngular, AdaptiveAngular)
 from .discrete import (NormalDiscrete, SSAdaptiveNormalDiscrete,
-                       VeaAdaptiveNormalDiscrete,
+                       AdaptiveNormalDiscrete,
                        BoundedDiscrete, SSAdaptiveBoundedDiscrete,
-                       VeaAdaptiveBoundedDiscrete)
+                       AdaptiveBoundedDiscrete)
 
 
 proposals = {
     JointProposal.name: JointProposal,
     Normal.name: Normal,
     SSAdaptiveNormal.name: SSAdaptiveNormal,
-    VeaAdaptiveNormal.name: VeaAdaptiveNormal,
+    AdaptiveNormal.name: AdaptiveNormal,
     BoundedNormal.name: BoundedNormal,
     SSAdaptiveBoundedNormal.name: SSAdaptiveBoundedNormal,
-    VeaAdaptiveBoundedNormal.name: VeaAdaptiveBoundedNormal,
+    AdaptiveBoundedNormal.name: AdaptiveBoundedNormal,
     Angular.name: Angular,
     SSAdaptiveAngular.name: SSAdaptiveAngular,
-    VeaAdaptiveAngular.name: VeaAdaptiveAngular,
+    AdaptiveAngular.name: AdaptiveAngular,
     NormalDiscrete.name: NormalDiscrete,
     SSAdaptiveNormalDiscrete.name: SSAdaptiveNormalDiscrete,
-    VeaAdaptiveNormalDiscrete.name: VeaAdaptiveNormalDiscrete,
+    AdaptiveNormalDiscrete.name: AdaptiveNormalDiscrete,
     BoundedDiscrete.name: BoundedDiscrete,
     SSAdaptiveBoundedDiscrete.name: SSAdaptiveBoundedDiscrete,
-    VeaAdaptiveBoundedDiscrete.name: VeaAdaptiveBoundedDiscrete,
+    AdaptiveBoundedDiscrete.name: AdaptiveBoundedDiscrete,
 }

--- a/epsie/proposals/angular.py
+++ b/epsie/proposals/angular.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 import numpy
 from scipy import stats
 
-from .normal import (Normal, VeaAdaptiveSupport, SSAdaptiveSupport)
+from .normal import (Normal, AdaptiveSupport, SSAdaptiveSupport)
 from .bounded_normal import Boundaries
 
 
@@ -124,11 +124,11 @@ class Angular(Normal):
                                       scale=std).sum() - self._logfactor
 
 
-class VeaAdaptiveAngular(VeaAdaptiveSupport, Angular):
+class AdaptiveAngular(AdaptiveSupport, Angular):
     r"""An angular proposoal with adaptive variance, using the algorithm from
     Veitch et al.
 
-    See :py:class:`VeaAdaptiveSupport` for details on the adaptation algorithm.
+    See :py:class:`AdaptiveSupport` for details on the adaptation algorithm.
 
     Parameters
     ----------
@@ -143,16 +143,16 @@ class VeaAdaptiveAngular(VeaAdaptiveSupport, Angular):
         adaptation will be done once a chain exceeds this value.
     \**kwargs :
         All other keyword arguments are passed to
-        :py:func:`VeaAdaptiveSupport.setup_adaptation`. See that function for
+        :py:func:`AdaptiveSupport.setup_adaptation`. See that function for
         details.
     """
-    name = 'vea_adaptive_angular'
+    name = 'adaptive_angular'
     symmetric = True
 
     def __init__(self, parameters, adaptation_duration,
                  **kwargs):
         # set the parameters, initialize the covariance matrix
-        super(VeaAdaptiveAngular, self).__init__(parameters)
+        super(AdaptiveAngular, self).__init__(parameters)
         # all parameters have the same (cyclic) boundaries
         boundaries = {p: Boundaries((0, 2*self._halfwidth*self._factor))
                       for p in self.parameters}

--- a/epsie/proposals/bounded_normal.py
+++ b/epsie/proposals/bounded_normal.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 import numpy
 from scipy import stats
 
-from .normal import (Normal, VeaAdaptiveSupport, SSAdaptiveSupport)
+from .normal import (Normal, AdaptiveSupport, SSAdaptiveSupport)
 
 
 class BoundedNormal(Normal):
@@ -131,11 +131,11 @@ class BoundedNormal(Normal):
         return stats.truncnorm.logpdf(xi, a, b, loc=mu, scale=self._std).sum()
 
 
-class VeaAdaptiveBoundedNormal(VeaAdaptiveSupport, BoundedNormal):
+class AdaptiveBoundedNormal(AdaptiveSupport, BoundedNormal):
     r"""A bounded normal proposoal with adaptive variance, using the algorithm
     from Vetich et al.
 
-    See :py:class:`VeaAdaptiveSupport` for details on the adaptation algorithm.
+    See :py:class:`AdaptiveSupport` for details on the adaptation algorithm.
 
     Parameters
     ----------
@@ -153,13 +153,13 @@ class VeaAdaptiveBoundedNormal(VeaAdaptiveSupport, BoundedNormal):
         :py:func:`AdaptiveSupport.setup_adaptation`. See that function for
         details.
     """
-    name = 'vea_adaptive_bounded_normal'
+    name = 'adaptive_bounded_normal'
     symmetric = False
 
     def __init__(self, parameters, boundaries, adaptation_duration,
                  **kwargs):
         # set the parameters, initialize the covariance matrix
-        super(VeaAdaptiveBoundedNormal, self).__init__(parameters,
+        super(AdaptiveBoundedNormal, self).__init__(parameters,
                                                        boundaries)
         # set up the adaptation parameters
         self.setup_adaptation(self.boundaries, adaptation_duration, **kwargs)

--- a/epsie/proposals/discrete.py
+++ b/epsie/proposals/discrete.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 import numpy
 from scipy import stats
 
-from .normal import (Normal, VeaAdaptiveSupport, SSAdaptiveSupport)
+from .normal import (Normal, AdaptiveSupport, SSAdaptiveSupport)
 from .bounded_normal import (BoundedNormal)
 
 
@@ -316,11 +316,11 @@ class SSAdaptiveBoundedDiscrete(SSAdaptiveSupport, BoundedDiscrete):
         self.setup_adaptation(**kwargs)
 
 
-class VeaAdaptiveNormalDiscrete(VeaAdaptiveSupport, NormalDiscrete):
+class AdaptiveNormalDiscrete(AdaptiveSupport, NormalDiscrete):
     r"""A discrete proposoal with adaptive variance, using the algorithm from
     Veitch et al.
 
-    See :py:class:`VeaAdaptiveSupport` for details on the adaptation algorithm.
+    See :py:class:`AdaptiveSupport` for details on the adaptation algorithm.
 
     Parameters
     ----------
@@ -338,21 +338,21 @@ class VeaAdaptiveNormalDiscrete(VeaAdaptiveSupport, NormalDiscrete):
         :py:func:`AdaptiveSupport.setup_adaptation`. See that function for
         details.
     """
-    name = 'vea_adaptive_discrete'
+    name = 'adaptive_discrete'
     symmetric = True
 
     def __init__(self, parameters, prior_widths, adaptation_duration,
                  **kwargs):
         # set the parameters, initialize the covariance matrix
-        super(VeaAdaptiveNormalDiscrete, self).__init__(parameters)
+        super(AdaptiveNormalDiscrete, self).__init__(parameters)
         # set up the adaptation parameters
         self.setup_adaptation(prior_widths, adaptation_duration, **kwargs)
 
 
-class VeaAdaptiveBoundedDiscrete(VeaAdaptiveSupport, BoundedDiscrete):
+class AdaptiveBoundedDiscrete(AdaptiveSupport, BoundedDiscrete):
     r"""A bounded discrete proposoal with adaptive variance.
 
-    See :py:class:`VeaAdaptiveSupport` for details on the adaptation algorithm.
+    See :py:class:`AdaptiveSupport` for details on the adaptation algorithm.
 
     Parameters
     ----------
@@ -370,13 +370,13 @@ class VeaAdaptiveBoundedDiscrete(VeaAdaptiveSupport, BoundedDiscrete):
         :py:func:`AdaptiveSupport.setup_adaptation`. See that function for
         details.
     """
-    name = 'vea_adaptive_bounded_discrete'
+    name = 'adaptive_bounded_discrete'
     symmetric = False
 
     def __init__(self, parameters, boundaries, adaptation_duration,
                  **kwargs):
         # set the parameters, initialize the covariance matrix
-        super(VeaAdaptiveBoundedDiscrete, self).__init__(
+        super(AdaptiveBoundedDiscrete, self).__init__(
             parameters, boundaries)
         # set up the adaptation parameters
         self.setup_adaptation(self.boundaries, adaptation_duration, **kwargs)

--- a/epsie/proposals/normal.py
+++ b/epsie/proposals/normal.py
@@ -191,7 +191,7 @@ class Normal(BaseProposal):
 
 
 @add_metaclass(ABCMeta)
-class VeaAdaptiveSupport(object):
+class AdaptiveSupport(object):
     r"""Utility class for adding adaptive variance support to a proposal.
 
     The adaptation algorithm is based on Eqs. 35 and 36 of Veitch et al. [1]_.
@@ -364,10 +364,10 @@ class VeaAdaptiveSupport(object):
         self._std = state['std']
 
 
-class VeaAdaptiveNormal(VeaAdaptiveSupport, Normal):
+class AdaptiveNormal(AdaptiveSupport, Normal):
     r"""Uses a normal distribution with adaptive variance for proposals.
 
-    See :py:class:`VeaAdaptiveSupport` for details on the adaptation algorithm.
+    See :py:class:`AdaptiveSupport` for details on the adaptation algorithm.
 
     Parameters
     ----------
@@ -382,16 +382,16 @@ class VeaAdaptiveNormal(VeaAdaptiveSupport, Normal):
         adaptation will be done once a chain exceeds this value.
     \**kwargs :
         All other keyword arguments are passed to
-        :py:func:`VeaAdaptiveSupport.setup_adaptation`. See that function for
+        :py:func:`AdaptiveSupport.setup_adaptation`. See that function for
         details.
     """
-    name = 'vea_adaptive_normal'
+    name = 'adaptive_normal'
     symmetric = True
 
     def __init__(self, parameters, prior_widths, adaptation_duration,
                  **kwargs):
         # set the parameters, initialize the covariance matrix
-        super(VeaAdaptiveNormal, self).__init__(parameters)
+        super(AdaptiveNormal, self).__init__(parameters)
         # set up the adaptation parameters
         self.setup_adaptation(prior_widths, adaptation_duration, **kwargs)
 

--- a/examples/test_adaptive_normal.ipynb
+++ b/examples/test_adaptive_normal.ipynb
@@ -30,7 +30,7 @@
     "import epsie\n",
     "from epsie import make_betas_ladder\n",
     "from epsie.samplers import ParallelTemperedSampler\n",
-    "from epsie.proposals import VeaAdaptiveNormal\n",
+    "from epsie.proposals import AdaptiveNormal\n",
     "import multiprocessing"
    ]
   },
@@ -124,7 +124,7 @@
    "source": [
     "adaptation_duration = 512\n",
     "prior_widths = {p: abs(bnds[1] - bnds[0]) for p, bnds in model.prior_bounds.items()}\n",
-    "proposal = VeaAdaptiveNormal(model.params, prior_widths, adaptation_duration=adaptation_duration)"
+    "proposal = AdaptiveNormal(model.params, prior_widths, adaptation_duration=adaptation_duration)"
    ]
   },
   {
@@ -309,7 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll plot the acceptance rate for each chain, which we define here as the number of times a proposal was accepted divided by the total number of iterations. We expect this to be close to ~0.23 for the coldest chain, as this was the target rate of the `VeaAdaptiveNormal` proposal that we used."
+    "We'll plot the acceptance rate for each chain, which we define here as the number of times a proposal was accepted divided by the total number of iterations. We expect this to be close to ~0.23 for the coldest chain, as this was the target rate of the `AdaptiveNormal` proposal that we used."
    ]
   },
   {
@@ -2002,7 +2002,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The sampler can be checkpointed by getting its current state with `sampler.state`. Let's check that this still works with the `VeaAdaptiveNormal` proposal. To demonstrate this, we'll save the current state of the sampler to a checkpoint HDF5 file, then run it for another set of iterations. We'll then create a new sampler, and set it's state using the checkpoint. Running the same sampler for the same number of iterations should produce the same results.\n",
+    "The sampler can be checkpointed by getting its current state with `sampler.state`. Let's check that this still works with the `AdaptiveNormal` proposal. To demonstrate this, we'll save the current state of the sampler to a checkpoint HDF5 file, then run it for another set of iterations. We'll then create a new sampler, and set it's state using the checkpoint. Running the same sampler for the same number of iterations should produce the same results.\n",
     "\n",
     "*Note:* Since we will be reading/writing from an HDF5 file, we'll need `h5py` installed. This is not one of the required packages for epsie, so if you don't have it, uncomment the next line to install it. If you don't wish to use this functionality, or prefer to save checkpoints using pickle or some other file format, you do not need to use HDF5."
    ]

--- a/examples/test_angular.ipynb
+++ b/examples/test_angular.ipynb
@@ -8147,7 +8147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from epsie.proposals import (VeaAdaptiveAngular, VeaAdaptiveBoundedNormal, VeaAdaptiveNormal)"
+    "from epsie.proposals import (AdaptiveAngular, AdaptiveBoundedNormal, AdaptiveNormal)"
    ]
   },
   {
@@ -8182,8 +8182,8 @@
    "outputs": [],
    "source": [
     "prior_widths = {p: abs(bnds) for p, bnds in model.prior_bounds.items()}\n",
-    "prop = VeaAdaptiveAngular(model.params, adaptation_duration=adaptation_duration)\n",
-    "prop_norm = VeaAdaptiveNormal(model.params, prior_widths, adaptation_duration=adaptation_duration)"
+    "prop = AdaptiveAngular(model.params, adaptation_duration=adaptation_duration)\n",
+    "prop_norm = AdaptiveNormal(model.params, prior_widths, adaptation_duration=adaptation_duration)"
    ]
   },
   {
@@ -8213,8 +8213,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(<epsie.proposals.angular.VeaAdaptiveAngular object at 0x11e3d1438>,)\n",
-      "(<epsie.proposals.normal.VeaAdaptiveNormal object at 0x11ddfc128>,)\n"
+      "(<epsie.proposals.angular.AdaptiveAngular object at 0x11e3d1438>,)\n",
+      "(<epsie.proposals.normal.AdaptiveNormal object at 0x11ddfc128>,)\n"
      ]
     }
    ],
@@ -9238,10 +9238,10 @@
    "outputs": [],
    "source": [
     "prior_widths = {p: abs(bnds) for p, bnds in model.prior_bounds.items()}\n",
-    "ampprop = VeaAdaptiveBoundedNormal(['amp'], boundaries={'amp': model.prior_bounds['amp']},\n",
+    "ampprop = AdaptiveBoundedNormal(['amp'], boundaries={'amp': model.prior_bounds['amp']},\n",
     "                                adaptation_duration=adaptation_duration)\n",
-    "phiprop = VeaAdaptiveAngular(['phi'], adaptation_duration=adaptation_duration)\n",
-    "prop_norm = VeaAdaptiveNormal(model.params, prior_widths, adaptation_duration=adaptation_duration)"
+    "phiprop = AdaptiveAngular(['phi'], adaptation_duration=adaptation_duration)\n",
+    "prop_norm = AdaptiveNormal(model.params, prior_widths, adaptation_duration=adaptation_duration)"
    ]
   },
   {
@@ -9271,8 +9271,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(<epsie.proposals.bounded_normal.VeaAdaptiveBoundedNormal object at 0x11e3d1470>, <epsie.proposals.angular.VeaAdaptiveAngular object at 0x11e3d1438>)\n",
-      "(<epsie.proposals.normal.VeaAdaptiveNormal object at 0x11e003470>,)\n"
+      "(<epsie.proposals.bounded_normal.AdaptiveBoundedNormal object at 0x11e3d1470>, <epsie.proposals.angular.AdaptiveAngular object at 0x11e3d1438>)\n",
+      "(<epsie.proposals.normal.AdaptiveNormal object at 0x11e003470>,)\n"
      ]
     }
    ],

--- a/test/test_adaptive_normal.py
+++ b/test/test_adaptive_normal.py
@@ -22,7 +22,7 @@ import itertools
 import pytest
 import numpy
 
-from epsie.proposals import (SSAdaptiveNormal, VeaAdaptiveNormal)
+from epsie.proposals import (SSAdaptiveNormal, AdaptiveNormal)
 from _utils import Model
 
 from test_ptsampler import _create_sampler
@@ -41,7 +41,7 @@ def _setup_proposal(model, proposal_name, params=None,
                     cov=None, adaptation_duration=None):
     if params is None:
         params = model.params
-    if proposal_name.startswith('vea_adaptive'):
+    if proposal_name.startswith('adaptive'):
         return _setup_vea_proposal(model, params, adaptation_duration)
     else:
         return SSAdaptiveNormal(params, cov=cov)
@@ -53,13 +53,13 @@ def _setup_vea_proposal(model, params, adaptation_duration=None):
     prior_widths = {p: abs(bnds[1] - bnds[0])
                     for p, bnds in model.prior_bounds.items()
                     if p in params}
-    return VeaAdaptiveNormal(params, prior_widths,
+    return AdaptiveNormal(params, prior_widths,
                              adaptation_duration=adaptation_duration)
 
 
 @pytest.mark.parametrize('nprocs', [1, 4])
 @pytest.mark.parametrize('proposal_name', ['ss_adaptive_normal',
-                                           'vea_adaptive_normal'])
+                                           'adaptive_normal'])
 def test_std_changes(nprocs, proposal_name, model=None):
     """Tests that the standard deviation changes after a few jumps for the type
     of proposal specified by ``proposal_name``.
@@ -96,7 +96,7 @@ def _test_std_changes(nprocs, proposal, model):
             current_std[ii, jj, :] = thisprop.std
     assert (initial_std != current_std).all()
     # vea adaptive proposals shut the adaptation after the adaption duration
-    if proposal.name.startswith('vea_adaptive'):
+    if proposal.name.startswith('adaptive'):
         # now run past the adaptation duration; since we have gone past it, the
         # standard deviations should no longer change
         sampler.run(ITERINT//2)
@@ -114,7 +114,7 @@ def _test_std_changes(nprocs, proposal, model):
 
 @pytest.mark.parametrize('nprocs', [1, 4])
 @pytest.mark.parametrize('proposal_name', ['ss_adaptive_normal',
-                                           'vea_adaptive_normal'])
+                                           'adaptive_normal'])
 def test_chains(nprocs, proposal_name):
     """Runs the PTSampler ``test_chains`` test using the adaptive normal
     proposal.
@@ -129,7 +129,7 @@ def test_chains(nprocs, proposal_name):
 
 @pytest.mark.parametrize('nprocs', [1, 4])
 @pytest.mark.parametrize('proposal_name', ['ss_adaptive_normal',
-                                           'vea_adaptive_normal'])
+                                           'adaptive_normal'])
 def test_checkpointing(nprocs, proposal_name):
     """Performs the same checkpointing test as for the PTSampler, but using
     the adaptive normal proposal.
@@ -141,7 +141,7 @@ def test_checkpointing(nprocs, proposal_name):
 
 @pytest.mark.parametrize('nprocs', [1, 4])
 @pytest.mark.parametrize('proposal_name', ['ss_adaptive_normal',
-                                           'vea_adaptive_normal'])
+                                           'adaptive_normal'])
 def test_seed(nprocs, proposal_name):
     """Runs the PTSampler ``test_seed`` using the adaptive normal proposal.
     """
@@ -152,7 +152,7 @@ def test_seed(nprocs, proposal_name):
 
 @pytest.mark.parametrize('nprocs', [1, 4])
 @pytest.mark.parametrize('proposal_name', ['ss_adaptive_normal',
-                                           'vea_adaptive_normal'])
+                                           'adaptive_normal'])
 def test_clear_memory(nprocs, proposal_name):
     """Runs the PTSampler ``test_clear_memoory`` using the adaptive normal
     proposal.

--- a/test/test_angular.py
+++ b/test/test_angular.py
@@ -42,7 +42,7 @@ def _setup_proposal(name, parameters, cov=None,
                     adaptation_duration=None):
     if name == 'ss_adaptive_angular' or name == 'angular':
         return proposals[name](parameters, cov=cov)
-    elif name == 'vea_adaptive_angular':
+    elif name == 'adaptive_angular':
         if adaptation_duration is None:
             adaptation_duration = ADAPTATION_DURATION
         return proposals[name](parameters, adaptation_duration)
@@ -54,7 +54,7 @@ def _setup_proposal(name, parameters, cov=None,
                          [('angular', None),
                           ('angular', 2.1),
                           ('ss_adaptive_angular', None),
-                          ('vea_adaptive_angular', None)])
+                          ('adaptive_angular', None)])
 def test_jumps_in_bounds(proposal_name, cov):
     """Tests that all jumps are in 0, 2pi."""
     proposal = _setup_proposal(proposal_name, ['phi'], cov)
@@ -89,7 +89,7 @@ def test_logpdf(params, cov):
 
 @pytest.mark.parametrize('nprocs', [1, 4])
 @pytest.mark.parametrize('proposal_name', ['ss_adaptive_angular',
-                                           'vea_adaptive_angular'])
+                                           'adaptive_angular'])
 def test_std_changes(nprocs, proposal_name, model=None):
     """Tests that the standard deviation changes after a few jumps for the type
     of proposal specified by ``proposal_name``.
@@ -103,7 +103,7 @@ def test_std_changes(nprocs, proposal_name, model=None):
 
 @pytest.mark.parametrize('proposal_name', ['angular',
                                            'ss_adaptive_angular',
-                                           'vea_adaptive_angular'])
+                                           'adaptive_angular'])
 @pytest.mark.parametrize('nprocs', [1, 4])
 def test_chains(proposal_name, nprocs):
     """Runs the PTSampler ``test_chains`` test using the angular proposal.
@@ -115,7 +115,7 @@ def test_chains(proposal_name, nprocs):
 
 @pytest.mark.parametrize('proposal_name', ['angular',
                                            'ss_adaptive_angular',
-                                           'vea_adaptive_angular'])
+                                           'adaptive_angular'])
 @pytest.mark.parametrize('nprocs', [1, 4])
 def test_checkpointing(proposal_name, nprocs):
     """Performs the same checkpointing test as for the PTSampler, but using
@@ -128,7 +128,7 @@ def test_checkpointing(proposal_name, nprocs):
 
 @pytest.mark.parametrize('proposal_name', ['angular',
                                            'ss_adaptive_angular',
-                                           'vea_adaptive_angular'])
+                                           'adaptive_angular'])
 @pytest.mark.parametrize('nprocs', [1, 4])
 def test_seed(proposal_name, nprocs):
     """Runs the PTSampler ``test_seed`` using the angular proposal.
@@ -140,7 +140,7 @@ def test_seed(proposal_name, nprocs):
 
 @pytest.mark.parametrize('proposal_name', ['angular',
                                            'ss_adaptive_angular',
-                                           'vea_adaptive_angular'])
+                                           'adaptive_angular'])
 @pytest.mark.parametrize('nprocs', [1, 4])
 def test_clear_memory(proposal_name, nprocs):
     """Runs the PTSampler ``test_clear_memoory`` using the angular proposal.

--- a/test/test_bounded_normal.py
+++ b/test/test_bounded_normal.py
@@ -44,7 +44,7 @@ def _setup_proposal(name, parameters, boundaries, cov=None,
                     adaptation_duration=None):
     if name == 'bounded_normal' or name == 'ss_adaptive_bounded_normal':
         return proposals[name](parameters, boundaries, cov=cov)
-    elif name == 'vea_adaptive_bounded_normal':
+    elif name == 'adaptive_bounded_normal':
         if adaptation_duration is None:
             adaptation_duration = ADAPTATION_DURATION
         return proposals[name](parameters, boundaries,
@@ -57,7 +57,7 @@ def _setup_proposal(name, parameters, boundaries, cov=None,
                          [('bounded_normal', None),
                           ('bounded_normal', 4),
                           ('ss_adaptive_bounded_normal', None),
-                          ('vea_adaptive_bounded_normal', None)])
+                          ('adaptive_bounded_normal', None)])
 @pytest.mark.parametrize('xmin,xmax',
                          [(-1, 1), (1.2, 2.8), (-42, -23)])
 def test_jumps_in_bounds(proposal_name, cov, xmin, xmax):
@@ -76,7 +76,7 @@ def test_jumps_in_bounds(proposal_name, cov, xmin, xmax):
 
 @pytest.mark.parametrize('nprocs', [1, 4])
 @pytest.mark.parametrize('proposal_name', ['ss_adaptive_bounded_normal',
-                                           'vea_adaptive_bounded_normal'])
+                                           'adaptive_bounded_normal'])
 def test_std_changes(nprocs, proposal_name, model=None):
     """Tests that the standard deviation changes after a few jumps for the type
     of proposal specified by ``proposal_name``.
@@ -90,7 +90,7 @@ def test_std_changes(nprocs, proposal_name, model=None):
 
 @pytest.mark.parametrize('proposal_name', ['bounded_normal',
                                            'ss_adaptive_bounded_normal',
-                                           'vea_adaptive_bounded_normal'])
+                                           'adaptive_bounded_normal'])
 @pytest.mark.parametrize('nprocs', [1, 4])
 def test_chains(proposal_name, nprocs):
     """Runs the PTSampler ``test_chains`` test using the bounded normal
@@ -107,7 +107,7 @@ def test_chains(proposal_name, nprocs):
 
 @pytest.mark.parametrize('proposal_name', ['bounded_normal',
                                            'ss_adaptive_bounded_normal',
-                                           'vea_adaptive_bounded_normal'])
+                                           'adaptive_bounded_normal'])
 @pytest.mark.parametrize('nprocs', [1, 4])
 def test_checkpointing(proposal_name, nprocs):
     """Performs the same checkpointing test as for the PTSampler, but using
@@ -120,7 +120,7 @@ def test_checkpointing(proposal_name, nprocs):
 
 @pytest.mark.parametrize('proposal_name', ['bounded_normal',
                                            'ss_adaptive_bounded_normal',
-                                           'vea_adaptive_bounded_normal'])
+                                           'adaptive_bounded_normal'])
 @pytest.mark.parametrize('nprocs', [1, 4])
 def test_seed(proposal_name, nprocs):
     """Runs the PTSampler ``test_seed`` using the adaptive normal proposal.
@@ -132,7 +132,7 @@ def test_seed(proposal_name, nprocs):
 
 @pytest.mark.parametrize('proposal_name', ['bounded_normal',
                                            'ss_adaptive_bounded_normal',
-                                           'vea_adaptive_bounded_normal'])
+                                           'adaptive_bounded_normal'])
 @pytest.mark.parametrize('nprocs', [1, 4])
 def test_clear_memory(proposal_name, nprocs):
     """Runs the PTSampler ``test_clear_memoory`` using the adaptive normal

--- a/test/test_discrete.py
+++ b/test/test_discrete.py
@@ -40,7 +40,7 @@ SWAP_INTERVAL = 1
 
 def _setup_proposal(name, parameters, boundaries=None, cov=None,
                     adaptation_duration=None):
-    if name.startswith('vea_adaptive'):
+    if name.startswith('adaptive'):
         if adaptation_duration is None:
             adaptation_duration = ADAPTATION_DURATION
         return proposals[name](parameters, boundaries,
@@ -55,7 +55,7 @@ def _setup_proposal(name, parameters, boundaries=None, cov=None,
                          [('bounded_discrete', None),
                           ('bounded_discrete', 4),
                           ('ss_adaptive_bounded_discrete', None),
-                          ('vea_adaptive_bounded_discrete', None)])
+                          ('adaptive_bounded_discrete', None)])
 @pytest.mark.parametrize('kmin,kmax',
                          [(0, 16), (1, 11)])
 def test_jumps_in_bounds(proposal_name, cov, kmin, kmax):
@@ -84,10 +84,10 @@ def test_jumps_in_bounds(proposal_name, cov, kmin, kmax):
 
 @pytest.mark.parametrize('proposal_name', ['discrete',
                                            'ss_adaptive_discrete',
-                                           'vea_adaptive_discrete',
+                                           'adaptive_discrete',
                                            'bounded_discrete',
                                            'ss_adaptive_bounded_discrete',
-                                           'vea_adaptive_bounded_discrete'])
+                                           'adaptive_bounded_discrete'])
 def test_logpdf(proposal_name):
     """Tests that the logpdf function is constant for two values with the same
     integer value.
@@ -111,8 +111,8 @@ def test_logpdf(proposal_name):
 @pytest.mark.parametrize('nprocs', [1, 4])
 @pytest.mark.parametrize('proposal_name', ['ss_adaptive_discrete',
                                            'ss_adaptive_bounded_discrete',
-                                           'vea_adaptive_discrete',
-                                           'vea_adaptive_bounded_discrete'])
+                                           'adaptive_discrete',
+                                           'adaptive_bounded_discrete'])
 def test_std_changes(nprocs, proposal_name):
     """Tests that the standard deviation of the adaptive proposals change
     after a few jumps.
@@ -125,10 +125,10 @@ def test_std_changes(nprocs, proposal_name):
 
 @pytest.mark.parametrize('proposal_name', ['discrete',
                                            'ss_adaptive_discrete',
-                                           'vea_adaptive_discrete',
+                                           'adaptive_discrete',
                                            'bounded_discrete',
                                            'ss_adaptive_bounded_discrete',
-                                           'vea_adaptive_bounded_discrete'])
+                                           'adaptive_bounded_discrete'])
 @pytest.mark.parametrize('nprocs', [1, 4])
 def test_chains(proposal_name, nprocs):
     """Runs the PTSampler ``test_chains`` test using the bounded normal
@@ -141,10 +141,10 @@ def test_chains(proposal_name, nprocs):
 
 @pytest.mark.parametrize('proposal_name', ['discrete',
                                            'ss_adaptive_discrete',
-                                           'vea_adaptive_discrete',
+                                           'adaptive_discrete',
                                            'bounded_discrete',
                                            'ss_adaptive_bounded_discrete',
-                                           'vea_adaptive_bounded_discrete'])
+                                           'adaptive_bounded_discrete'])
 @pytest.mark.parametrize('nprocs', [1, 4])
 def test_checkpointing(proposal_name, nprocs):
     """Performs the same checkpointing test as for the PTSampler, but using
@@ -157,10 +157,10 @@ def test_checkpointing(proposal_name, nprocs):
 
 @pytest.mark.parametrize('proposal_name', ['discrete',
                                            'ss_adaptive_discrete',
-                                           'vea_adaptive_discrete',
+                                           'adaptive_discrete',
                                            'bounded_discrete',
                                            'ss_adaptive_bounded_discrete',
-                                           'vea_adaptive_bounded_discrete'])
+                                           'adaptive_bounded_discrete'])
 @pytest.mark.parametrize('nprocs', [1, 4])
 def test_seed(proposal_name, nprocs):
     """Runs the PTSampler ``test_seed`` using the adaptive normal proposal.
@@ -172,10 +172,10 @@ def test_seed(proposal_name, nprocs):
 
 @pytest.mark.parametrize('proposal_name', ['discrete',
                                            'ss_adaptive_discrete',
-                                           'vea_adaptive_discrete',
+                                           'adaptive_discrete',
                                            'bounded_discrete',
                                            'ss_adaptive_bounded_discrete',
-                                           'vea_adaptive_bounded_discrete'])
+                                           'adaptive_bounded_discrete'])
 @pytest.mark.parametrize('nprocs', [1, 4])
 def test_clear_memory(proposal_name, nprocs):
     """Runs the PTSampler ``test_clear_memoory`` using the adaptive normal


### PR DESCRIPTION
Renames `VeaAdaptive` proposals back to `Adaptive` proposals, so as not to break backward compatibility with version 0.5.