### PR TITLE
Ensure jumps are from integers in bounded discrete

### DIFF
--- a/epsie/proposals/discrete.py
+++ b/epsie/proposals/discrete.py
@@ -207,7 +207,7 @@ class BoundedDiscrete(BoundedNormal):
                 # for values < 0, we want the floor; for values > 0, the
                 # ceiling
                 deltax = int(_floorceil(deltax))
-                newpt = {p: fromx[p]+deltax}
+                newpt = {p: int(fromx[p])+deltax}
                 inbnds = newpt in self
             to_x.update(newpt)
         return to_x


### PR DESCRIPTION
Makes sure `fromx` in the bounded discrete proposal is an integer.