### PR TITLE
More negative eigenvalue fixes

### DIFF
--- a/epsie/__init__.py
+++ b/epsie/__init__.py
@@ -24,6 +24,7 @@ import os
 import sys
 import pickle
 from io import BytesIO
+import logging
 import numpy
 from numpy.random import (PCG64, SeedSequence)
 
@@ -56,6 +57,7 @@ def create_seed(seed=None):
     """
     if seed is None:
         seed = SeedSequence().entropy
+        logging.debug("Using seed: %i", seed)
     return seed
 
 

--- a/epsie/chain/chain.py
+++ b/epsie/chain/chain.py
@@ -509,11 +509,13 @@ class Chain(BaseChain):
             ar = numpy.exp(logar)
             if numpy.isnan(ar):
                 raise ValueError('NaN acceptance!'
+                                 '\nchain: {};\nbeta: {};'
                                  '\ncurrent position: {};'
                                  '\nproposed position: {};'
                                  '\nproposal state: {}'
-                                 .format(current_pos, proposal,
-                                 self.proposal_dist.state))
+                                 .format(self.chain_id, self.beta,
+                                         current_pos, proposal,
+                                         self.proposal_dist.state))
             u = self.random_generator.uniform()
             accept = u <= ar
         return accept, ar

--- a/epsie/chain/chain.py
+++ b/epsie/chain/chain.py
@@ -507,6 +507,13 @@ class Chain(BaseChain):
             accept = True
         else:
             ar = numpy.exp(logar)
+            if numpy.isnan(ar):
+                raise ValueError('NaN acceptance!'
+                                 '\ncurrent position: {};'
+                                 '\nproposed position: {};'
+                                 '\nproposal state: {}'
+                                 .format(current_pos, proposal,
+                                 self.proposal_dist.state))
             u = self.random_generator.uniform()
             accept = u <= ar
         return accept, ar

--- a/epsie/proposals/eigenvector.py
+++ b/epsie/proposals/eigenvector.py
@@ -159,7 +159,8 @@ class Eigenvector(BaseProposal):
         state = {'nsteps': self._nsteps,
                  'random_state': self.random_state,
                  'mu': self._mu,
-                 'cov': self._cov}
+                 'cov': self._cov,
+                 'ind': self._ind}
         return state
 
     def set_state(self, state):
@@ -168,7 +169,8 @@ class Eigenvector(BaseProposal):
         self._mu = state['mu']
         self._cov = state['cov']
         if self._cov is not None:
-            self._eigvals, self._eigvects = numpy.linalg.eigh(self._cov)
+            self.eigvals, self.eigvects = numpy.linalg.eigh(self._cov)
+        self._ind = state['ind']
 
     @property
     def _call_initial_proposal(self):

--- a/epsie/proposals/eigenvector.py
+++ b/epsie/proposals/eigenvector.py
@@ -18,7 +18,6 @@ from scipy.stats import norm
 
 from .base import (BaseProposal, BaseAdaptiveSupport)
 from .normal import (Normal, ATAdaptiveNormal)
-from .bounded_normal import (BoundedNormal, ATAdaptiveBoundedNormal)
 
 
 class Eigenvector(BaseProposal):
@@ -33,13 +32,14 @@ class Eigenvector(BaseProposal):
     stability_duration : int
         Number of initial steps done with a initial proposal specified by name
         in ``initial_proposal''. After this eigenvalues and eigenvectors are
-        evaluated (and never again) and jumps proposed along those.
-    initial_proposal : str (optional)
+        evaluated (and never again) and jumps proposed along those. This is
+        also used for the adaptation duration if the ``initial_proposal`` is
+        set to ``at_adaptive_normal``.
+    initial_proposal : {'at_adaptive_normal', 'normal'}
         Name of the initial proposal that is called before the number of
-        proposal seps exceeds ``stability_duration''. By default se to the
-        'epsie.proposals.ATAdaptiveProposal'. Supported options
-        include: 'normal', 'at_adaptive_proposal'
-    shuffle_rate : float (optional)
+        proposal steps exceeds ``stability_duration''. Default is
+        ``'at_adaptive_normal'``.
+    shuffle_rate : float, optional
         Probability of shuffling the eigenvector jump probabilities. By
         default 0.33.
     jump_interval : int, optional
@@ -68,19 +68,44 @@ class Eigenvector(BaseProposal):
                  initial_proposal='at_adaptive_normal'):
         self.parameters = parameters
         self.ndim = len(self.parameters)
+        # used for picking which direction to hop along
+        self._dims = numpy.arange(self.ndim)
         self.shuffle_rate = shuffle_rate
         self.start_step = 1  # Add support for this
         # store the jump interval information
         self.set_jump_interval(jump_interval, jump_interval_duration)
-        self.set_initial_proposal(initial_proposal, stability_duration)
+        # store the stability duration
+        self._stability_duration = int(stability_duration)
+        # set the initial proposal
+        if initial_proposal == 'normal':
+            self._initial_proposal = Normal(self.parameters)
+        elif initial_proposal == 'at_adaptive_normal':
+            self._initial_proposal = ATAdaptiveNormal(
+                self.parameters, adaptation_duration=self._stability_duration)
+        else:
+            raise ValueError("Proposal '{}' not implemented for eigenvector"
+                             .format(initial_proposal))
         # cache the eigenvector index used to produce a jump
         self._ind = None
         # cache the last jump scale
         self._dx = None
 
+    @BaseProposal.bit_generator.setter
+    def bit_generator(self, bit_generator):
+        """Sets the random bit generator.
+
+        Also sets the bit generator of the ``initial_proposal``.
+
+        See :py:class:`epsie.proposals.base.BaseProposal` for more details.
+        """
+        # this borrowed from: https://stackoverflow.com/a/31909212
+        BaseProposal.bit_generator.fset(self, bit_generator)
+        # set the initial too
+        self._initial_proposal.bit_generator = bit_generator
+
     @property
     def initial_proposal(self):
-        """Initial proposal used during the stabilit phase, before estimated
+        """Initial proposal used during the stability phase, before estimated
         eigenvectors become reliable."""
         return self._initial_proposal
 
@@ -89,25 +114,6 @@ class Eigenvector(BaseProposal):
         """Number of proposal steps during which ``self.initial_proposal'' is
         used instead of eigenvector jumps"""
         return self._stability_duration
-
-    def set_initial_proposal(self, proposal_name, duration, boundaries=None):
-        """Sets up the initial proposal used before able to get stable
-        eigenvector estimates."""
-        if proposal_name == 'normal':
-            self._initial_proposal = Normal(self.parameters)
-        elif proposal_name == 'at_adaptive_normal':
-            self._initial_proposal = ATAdaptiveNormal(
-                self.parameters, adaptation_duration=duration)
-        elif proposal_name == 'bounded_normal':
-            self._initial_proposal = BoundedNormal(self.parameters, boundaries)
-        elif proposal_name == 'at_adaptive_bounded_normal':
-            self._initial_proposal = ATAdaptiveBoundedNormal(
-                self.parameters, boundaries, adaptation_duration=duration)
-        else:
-            raise ValueError("Proposal '{}' not implemented for eigenvector"
-                             .format(proposal_name))
-        self._initial_proposal.bit_generator = self.bit_generator
-        self._stability_duration = int(duration)
 
     @property
     def eigvals(self):
@@ -183,10 +189,17 @@ class Eigenvector(BaseProposal):
     def _jump_eigenvector(self):
         """Picks along which eigenvector to jump."""
         probs = self.eigvals / numpy.sum(self.eigvals)
+        dims = self._dims
         # with shuffle_rate probability randomly shuffle the probabilities
         if self.random_generator.uniform() < self.shuffle_rate:
+            # make sure we don't shuffle any 0 probabilities
+            isz = probs == 0.
+            if isz.any():
+                mask = ~isz
+                probs = probs[mask]
+                dims = dims[mask]
             self.random_generator.shuffle(probs)
-        return self.random_generator.choice(self.ndim, p=probs)
+        return self.random_generator.choice(dims, p=probs)
 
     def _jump(self, fromx):
         if self._call_initial_proposal:
@@ -304,17 +317,19 @@ class AdaptiveEigenvectorSupport(BaseAdaptiveSupport):
                 'random_state': self.random_state,
                 'mu': self._mu,
                 'cov': self._cov,
+                'ind': self._ind,
                 'log_lambda': self._log_lambda}
 
     def set_state(self, state):
-        self.random_state = state['random_state']
         self._nsteps = state['nsteps']
+        self.random_state = state['random_state']
         self._mu = state['mu']
         self._cov = state['cov']
-        self._log_lambda = state['log_lambda']
         if self._cov is not None:
             self.eigvals, self.eigvects = numpy.linalg.eigh(self._cov)
             self.eigvals *= numpy.exp(self._log_lambda)
+        self._ind = state['ind']
+        self._log_lambda = state['log_lambda']
 
 
 class AdaptiveEigenvector(AdaptiveEigenvectorSupport, Eigenvector):

--- a/test/test_bounded_eigenvector.py
+++ b/test/test_bounded_eigenvector.py
@@ -55,7 +55,6 @@ def test_jumps_in_bounds(proposal_name, xmin, xmax):
     eigenvector jumps are in bounds.
     """
     model = Model()
-    print(xmin)
     bnd = Boundaries((xmin, xmax))
     model.prior_bounds.update({'x0': bnd})
     model.prior_dist.update({'x0': stats.uniform(bnd.lower, abs(bnd))})


### PR DESCRIPTION
PR #38 fixed small and negative eigenvalues in the Eigenvector (and inherited) proposals by setting them to zero. However, due to the shuffling in `_jump_eigenvector`, the 0 eigenvalues can sometimes be selected for a jump. That results in a NaN when the logpdf is evaluated, since the eigenvalue sets the variance of the normal distribution that's used. This fixes this by excluding 0 eigenvalues when shuffling probabilities in `_jump_eigenvector`.

This also adds several things to make results more reproducible, which I needed to track this bug down. They are:
 * The initial proposals in `*Eigenvector` were not using the same bit generators as the initial. This fixes that by modifying `Eigenvector` to set the initial proposals bit generator when its `bit_generator` is set.
 * Along those lines, the code in `set_initial_proposal` has been moved into `(Bounded)Eigenvector`'s `__init__`, since Bounded did something slightly different than the unbounded.
 * The `_ind` attribute is saved in the state, and restored when `set_state` is called.
 * The seed that's created by `create_seed` is printed in the debugging logging.
 * All of the test models use a seed now, so that the unit tests are more reproducible. (The `test_seed` test still will use a randomly generated seed, but that's on purpose.)

While this fixes what happens when a 0 eigenvalue is obtained, I think there is another underlying issue here. The `BoundedEigenvector` should not have gotten eigenvalues with 0 for the test model, as it sometimes was, since the test model is a 2D Gaussian. Not going to address in this PR, but here are some settings I found will get this to happen:
 * use the default `Model` (with the default seed in this PR)
 * set:
```
STABILITY_DURATION = 64
ADAPTATION_DURATION = 16
SWAP_INTERVAL = 1
NCHAINS = 4
NTEMPS = 3
ITERINT = 32
```
 * Initialize the PTSampler, with the above settings, and:
```
nprocs = 1
seed = 266898112101595934258451730772524202746
```
 * Run the sampler for `sampler.run(STABILITY_DURATION)`. Chain 1, coldest temperature, will then have a covariance matrix of:
```
array([[0.17048876, 0.52049453],
       [0.52049453, 1.58904647]])
```
 That yields an eigenvalue that is 0.