### PR TITLE
PT: Reset adaptation

### DIFF
--- a/epsie/chain/chain.py
+++ b/epsie/chain/chain.py
@@ -419,7 +419,7 @@ class Chain(BaseChain):
         for proposal in self.proposal_dist.proposals:
             # non-adaptive proposals will yield an attribute error
             try:
-                proposal.reset_adaptation()
+                proposal._reset_adaptation()
             except AttributeError:
                 pass
 

--- a/epsie/chain/chain.py
+++ b/epsie/chain/chain.py
@@ -414,6 +414,15 @@ class Chain(BaseChain):
         self._lastclear = self._iteration
         return self
 
+    def _reset_proposals(self):
+        """Reset the chain's adaptive proposals to the initial values."""
+        for proposal in self.proposal_dist.proposals:
+            # non-adaptive proposals will yield an attribute error
+            try:
+                proposal.reset_adaptation()
+            except AttributeError:
+                pass
+
     def __getitem__(self, index):
         """Returns all of the chain data at the requested index."""
         index = (-1)**(index < 0) * (index % len(self))

--- a/epsie/chain/chain.py
+++ b/epsie/chain/chain.py
@@ -414,7 +414,7 @@ class Chain(BaseChain):
         self._lastclear = self._iteration
         return self
 
-    def _reset_proposals(self):
+    def reset_proposals(self):
         """Reset the chain's adaptive proposals to the initial values."""
         for proposal in self.proposal_dist.proposals:
             # non-adaptive proposals will yield an attribute error

--- a/epsie/chain/ptchain.py
+++ b/epsie/chain/ptchain.py
@@ -105,7 +105,7 @@ class ParallelTemperedChain(BaseChain):
             # note that pass by reference is required here if setting
             # Tmax=infty
             adaptive_annealer.setup_annealing(self.betas)
-        self._reset_swap_proposals = reset_swap_proposals
+        self.reset_swap_proposals = reset_swap_proposals
 
         if self.ntemps > 1:
             # we pass ntemps=ntemps-1 here because there will be ntemps-1

--- a/epsie/chain/ptchain.py
+++ b/epsie/chain/ptchain.py
@@ -56,7 +56,7 @@ class ParallelTemperedChain(BaseChain):
     adaptive_annealer : object, optional
         Adaptive annealing that adjusts the temperature levels during runtime.
         By default `None`, meaning no annealing.
-    reset_proposals : bool, optional
+    reset_swap_proposals : bool, optional
         Whether to reset proposals' adaptation after each swap. By default
         no reset.
     bit_generator : :py:class:`epsie.BIT_GENERATOR` instance, optional
@@ -90,7 +90,7 @@ class ParallelTemperedChain(BaseChain):
     """
 
     def __init__(self, parameters, model, proposals, betas=1., swap_interval=1,
-                 adaptive_annealer=None, reset_proposals=False,
+                 adaptive_annealer=None, reset_swap_proposals=False,
                  bit_generator=None, chain_id=0):
         self.parameters = parameters
         self.model = model
@@ -105,7 +105,7 @@ class ParallelTemperedChain(BaseChain):
             # note that pass by reference is required here if setting
             # Tmax=infty
             adaptive_annealer.setup_annealing(self.betas)
-        self._reset_proposals = reset_proposals
+        self._reset_swap_proposals = reset_swap_proposals
 
         if self.ntemps > 1:
             # we pass ntemps=ntemps-1 here because there will be ntemps-1
@@ -284,9 +284,16 @@ class ParallelTemperedChain(BaseChain):
         return len(self.betas)
 
     @property
-    def reset_proposals(self):
+    def reset_swap_proposals(self):
         """Whether to reset proposals' adaptation after each swap."""
-        return self._reset_proposals
+        return self._reset_swap_proposals
+    
+    @reset_swap_proposals.setter
+    def reset_swap_proposals(self, reset_swap_proposals):
+        if not isinstance(reset_swap_proposals, bool):
+            raise ValueError("`reset_swap_proposals` must be a bool.")
+        self._reset_swap_proposals = reset_swap_proposals
+            
 
     def _concatenate_dicts(self, attr):
         """Concatenates dictionary attributes over all of the temperatures.
@@ -580,7 +587,7 @@ class ParallelTemperedChain(BaseChain):
             if self.hasblobs:
                 chain._blobs[ii] = new_blobs[tk]
             # Reset adaptation for swapped proposals
-            if self.reset_proposals and tk != swap_index[tk]:
+            if self.reset_swap_proposals and tk != swap_index[tk]:
                 chain._reset_proposals()
 
         self._temperature_acceptance[ii//self.swap_interval] = {

--- a/epsie/chain/ptchain.py
+++ b/epsie/chain/ptchain.py
@@ -533,7 +533,7 @@ class ParallelTemperedChain(BaseChain):
                 ar = 1.
                 swap = True
             else:
-                ar = numpy.exp(dbetas[tj]*(loglj - loglk))
+                ar = numpy.exp(logar)
                 u = self.random_generator.uniform()
                 swap = u <= ar
             if swap:

--- a/epsie/chain/ptchain.py
+++ b/epsie/chain/ptchain.py
@@ -583,7 +583,6 @@ class ParallelTemperedChain(BaseChain):
             if self.reset_proposals and tk != swap_index[tk]:
                 chain._reset_proposals()
 
-
         self._temperature_acceptance[ii//self.swap_interval] = {
             'acceptance_ratio': ars}
         self._temperature_swaps[ii//self.swap_interval] = {

--- a/epsie/chain/ptchain.py
+++ b/epsie/chain/ptchain.py
@@ -56,7 +56,7 @@ class ParallelTemperedChain(BaseChain):
     adaptive_annealer : object, optional
         Adaptive annealing that adjusts the temperature levels during runtime.
         By default `None`, meaning no annealing.
-    reset_swap_proposals : bool, optional
+    reset_after_swap : bool, optional
         Whether to reset proposals' adaptation after each swap. By default
         no reset.
     bit_generator : :py:class:`epsie.BIT_GENERATOR` instance, optional
@@ -90,7 +90,7 @@ class ParallelTemperedChain(BaseChain):
     """
 
     def __init__(self, parameters, model, proposals, betas=1., swap_interval=1,
-                 adaptive_annealer=None, reset_swap_proposals=False,
+                 adaptive_annealer=None, reset_after_swap=False,
                  bit_generator=None, chain_id=0):
         self.parameters = parameters
         self.model = model
@@ -105,7 +105,7 @@ class ParallelTemperedChain(BaseChain):
             # note that pass by reference is required here if setting
             # Tmax=infty
             adaptive_annealer.setup_annealing(self.betas)
-        self.reset_swap_proposals = reset_swap_proposals
+        self.reset_after_swap = reset_after_swap
 
         if self.ntemps > 1:
             # we pass ntemps=ntemps-1 here because there will be ntemps-1
@@ -284,15 +284,15 @@ class ParallelTemperedChain(BaseChain):
         return len(self.betas)
 
     @property
-    def reset_swap_proposals(self):
+    def reset_after_swap(self):
         """Whether to reset proposals' adaptation after each swap."""
-        return self._reset_swap_proposals
+        return self._reset_after_swap
 
-    @reset_swap_proposals.setter
-    def reset_swap_proposals(self, reset_swap_proposals):
-        if not isinstance(reset_swap_proposals, bool):
-            raise ValueError("`reset_swap_proposals` must be a bool.")
-        self._reset_swap_proposals = reset_swap_proposals
+    @reset_after_swap.setter
+    def reset_after_swap(self, reset_after_swap):
+        if not isinstance(reset_after_swap, bool):
+            raise ValueError("`reset_after_swap` must be a bool.")
+        self._reset_after_swap = reset_after_swap
 
     def _concatenate_dicts(self, attr):
         """Concatenates dictionary attributes over all of the temperatures.
@@ -586,7 +586,7 @@ class ParallelTemperedChain(BaseChain):
             if self.hasblobs:
                 chain._blobs[ii] = new_blobs[tk]
             # Reset adaptation for swapped proposals
-            if self.reset_swap_proposals and tk != swap_index[tk]:
+            if self.reset_after_swap and tk != swap_index[tk]:
                 chain._reset_proposals()
 
         self._temperature_acceptance[ii//self.swap_interval] = {

--- a/epsie/chain/ptchain.py
+++ b/epsie/chain/ptchain.py
@@ -287,13 +287,12 @@ class ParallelTemperedChain(BaseChain):
     def reset_swap_proposals(self):
         """Whether to reset proposals' adaptation after each swap."""
         return self._reset_swap_proposals
-    
+
     @reset_swap_proposals.setter
     def reset_swap_proposals(self, reset_swap_proposals):
         if not isinstance(reset_swap_proposals, bool):
             raise ValueError("`reset_swap_proposals` must be a bool.")
         self._reset_swap_proposals = reset_swap_proposals
-            
 
     def _concatenate_dicts(self, attr):
         """Concatenates dictionary attributes over all of the temperatures.

--- a/epsie/chain/ptchain.py
+++ b/epsie/chain/ptchain.py
@@ -580,7 +580,7 @@ class ParallelTemperedChain(BaseChain):
             if self.hasblobs:
                 chain._blobs[ii] = new_blobs[tk]
             # Reset adaptation for swapped proposals
-            if self.reset_adaptation and tk != swap_index[tk]:
+            if self.reset_proposals and tk != swap_index[tk]:
                 chain._reset_proposals()
 
 

--- a/epsie/proposals/base.py
+++ b/epsie/proposals/base.py
@@ -449,6 +449,13 @@ class BaseAdaptiveSupport(ABC):
                                       "resetting the adaptation."
                                       .format(self.name))
         self.start_step = self.nsteps
+
+        # Optionally reset also the eigenvector initial proposal
+        eigvect_init = self._initial_proposal_params.pop('eigvect_init', None)
+        if eigvect_init is not None:
+            for attr, val in eigvect_init.items():
+                setattr(self._initial_proposal, attr, val)
+        
         for attr, val in self._initial_proposal_params.items():
             setattr(self, attr, val)
 

--- a/epsie/proposals/base.py
+++ b/epsie/proposals/base.py
@@ -450,12 +450,6 @@ class BaseAdaptiveSupport(ABC):
                                       .format(self.name))
         self.start_step = self.nsteps
 
-        # Optionally reset also the eigenvector initial proposal
-        eigvect_init = self._initial_proposal_params.pop('eigvect_init', None)
-        if eigvect_init is not None:
-            for attr, val in eigvect_init.items():
-                setattr(self._initial_proposal, attr, val)
-
         for attr, val in self._initial_proposal_params.items():
             setattr(self, attr, val)
 

--- a/epsie/proposals/base.py
+++ b/epsie/proposals/base.py
@@ -397,6 +397,7 @@ class BaseAdaptiveSupport(ABC):
     """Abstract base class for all proposal classes.
     """
     _start_step = None
+    _initial_proposal_params = None
     _adaptation_duration = None
     _target_rate = None
 
@@ -438,6 +439,18 @@ class BaseAdaptiveSupport(ABC):
         if not 0.0 < target_rate < 1.0:
             raise ValueError("Target acceptance rate must be in range (0, 1)")
         self._target_rate = target_rate
+
+    def _reset_adaptation(self):
+        """Sets the proposal's adaptation scheme to the initial values
+        and possibly bumps up `start_step`.
+        """
+        if self._initial_proposal_params is None:
+            raise NotImplementedError("Proposal '{}' does not support "
+                                      "resetting the adaptation."
+                                      .format(self.name))
+        self.start_step += self.nsteps
+        for attr, val in self._initial_proposal_params.items():
+            setattr(self, attr, val)
 
     @abstractmethod
     def _update(self, chain):

--- a/epsie/proposals/base.py
+++ b/epsie/proposals/base.py
@@ -455,7 +455,7 @@ class BaseAdaptiveSupport(ABC):
         if eigvect_init is not None:
             for attr, val in eigvect_init.items():
                 setattr(self._initial_proposal, attr, val)
-        
+
         for attr, val in self._initial_proposal_params.items():
             setattr(self, attr, val)
 

--- a/epsie/proposals/base.py
+++ b/epsie/proposals/base.py
@@ -448,7 +448,7 @@ class BaseAdaptiveSupport(ABC):
             raise NotImplementedError("Proposal '{}' does not support "
                                       "resetting the adaptation."
                                       .format(self.name))
-        self.start_step += self.nsteps
+        self.start_step = self.nsteps
         for attr, val in self._initial_proposal_params.items():
             setattr(self, attr, val)
 

--- a/epsie/proposals/eigenvector.py
+++ b/epsie/proposals/eigenvector.py
@@ -259,6 +259,11 @@ class AdaptiveEigenvectorSupport(BaseAdaptiveSupport):
         # initialize mu to be zero
         self._mu = numpy.zeros(self.ndim)
 
+        self._initial_proposal_params = {
+            '_cov': self._cov,
+            '_mu': self._mu,
+            '_log_lambda': 0.0,}
+
     def recursive_covariance(self, chain):
         """Recursively updates the covariance given the latest observation.
         Weights all sampled points uniformly.
@@ -271,12 +276,6 @@ class AdaptiveEigenvectorSupport(BaseAdaptiveSupport):
             * (self._cov + N / (N**2 - 1) * numpy.matmul(dx, dx.T))
         self._mu = (N * self._mu + x) / (N + 1)
 
-        self._initial_proposal_params = {
-            '_cov': None,
-            '_mu': None,
-            '_log_lambda': 0.0,
-            'eigvect_init': self._initial_proposal._initial_proposal_params}
-
     def _update(self, chain):
         """Updates the adaptation based on whether the last jump was accepted.
 
@@ -284,7 +283,7 @@ class AdaptiveEigenvectorSupport(BaseAdaptiveSupport):
         """
         dk = self.nsteps - self.start_step + 1
         if 1 < dk < self.adaptation_duration:
-            self._recursive_covariance(chain)
+            self.recursive_covariance(chain)
             # update eigenvalues and eigenvectors
             self.eigvals, self.eigvects = numpy.linalg.eigh(self._cov)
             # update the scaling factor

--- a/epsie/proposals/eigenvector.py
+++ b/epsie/proposals/eigenvector.py
@@ -262,7 +262,7 @@ class AdaptiveEigenvectorSupport(BaseAdaptiveSupport):
         self._initial_proposal_params = {
             '_cov': self._cov,
             '_mu': self._mu,
-            '_log_lambda': 0.0,}
+            '_log_lambda': 0.0}
 
     def recursive_covariance(self, chain):
         """Recursively updates the covariance given the latest observation.

--- a/epsie/proposals/eigenvector.py
+++ b/epsie/proposals/eigenvector.py
@@ -229,7 +229,7 @@ class AdaptiveEigenvectorSupport(BaseAdaptiveSupport):
     ensuring that when the adaptation phase ends the vanishing decay tends to
     zero. By default assumes that the adaptation phase never ends (only
     decays with time)
-
+å
     References
     ----------
     [1] Andrieu, Christophe & Thoms, Johannes. (2008).
@@ -284,7 +284,7 @@ class AdaptiveEigenvectorSupport(BaseAdaptiveSupport):
         """
         dk = self.nsteps - self.start_step + 1
         if 1 < dk < self.adaptation_duration:
-            self._recursive_mean_cov(chain)
+            self._recursive_covariance(chain)
             # update eigenvalues and eigenvectors
             self.eigvals, self.eigvects = numpy.linalg.eigh(self._cov)
             # update the scaling factor

--- a/epsie/proposals/eigenvector.py
+++ b/epsie/proposals/eigenvector.py
@@ -282,10 +282,8 @@ class AdaptiveEigenvectorSupport(BaseAdaptiveSupport):
 
         This prepares the proposal for the next jump.
         """
-        dk = self.nsteps - (self.start_step - 1) - self.stability_duration + 1
-        if self._call_initial_proposal:
-            self._stability_update(chain)
-        elif dk < self.adaptation_duration:
+        dk = self.nsteps - self.start_step + 1
+        if 1 < dk < self.adaptation_duration:
             self._recursive_mean_cov(chain)
             # update eigenvalues and eigenvectors
             self.eigvals, self.eigvects = numpy.linalg.eigh(self._cov)

--- a/epsie/proposals/eigenvector.py
+++ b/epsie/proposals/eigenvector.py
@@ -251,6 +251,7 @@ class AdaptiveEigenvectorSupport(BaseAdaptiveSupport):
             Target acceptance rate. By default 0.234
         """
         self.target_rate = target_rate
+        self.start_step = 1
         self.adaptation_duration = adaptation_duration
         self._decay_const = adaptation_duration**(-0.6)
         self.start_step = start_step
@@ -270,15 +271,22 @@ class AdaptiveEigenvectorSupport(BaseAdaptiveSupport):
             * (self._cov + N / (N**2 - 1) * numpy.matmul(dx, dx.T))
         self._mu = (N * self._mu + x) / (N + 1)
 
+        self._initial_proposal_params = {
+            '_cov': None,
+            '_mu': None,
+            '_log_lambda': 0.0,
+            'eigvect_init': self._initial_proposal._initial_proposal_params}
+
     def _update(self, chain):
         """Updates the adaptation based on whether the last jump was accepted.
 
         This prepares the proposal for the next jump.
         """
-        dk = self.nsteps - self.start_step + 1
-        if 1 < dk < self.adaptation_duration:
-            # recursively update the covariance
-            self.recursive_covariance(chain)
+        dk = self.nsteps - (self.start_step - 1) - self.stability_duration + 1
+        if self._call_initial_proposal:
+            self._stability_update(chain)
+        elif dk < self.adaptation_duration:
+            self._recursive_mean_cov(chain)
             # update eigenvalues and eigenvectors
             self.eigvals, self.eigvects = numpy.linalg.eigh(self._cov)
             # update the scaling factor
@@ -296,7 +304,8 @@ class AdaptiveEigenvectorSupport(BaseAdaptiveSupport):
                 'mu': self._mu,
                 'cov': self._cov,
                 'ind': self._ind,
-                'log_lambda': self._log_lambda}
+                'log_lambda': self._log_lambda,
+                'start_step': self.start_step}
 
     def set_state(self, state):
         self._nsteps = state['nsteps']
@@ -308,6 +317,7 @@ class AdaptiveEigenvectorSupport(BaseAdaptiveSupport):
             self.eigvals, self.eigvects = numpy.linalg.eigh(self._cov)
             self.eigvals *= numpy.exp(self._log_lambda)
         self._ind = state['ind']
+        self.start_step = state['start_step']
 
 
 class AdaptiveEigenvector(AdaptiveEigenvectorSupport, Eigenvector):

--- a/epsie/proposals/normal.py
+++ b/epsie/proposals/normal.py
@@ -467,9 +467,9 @@ class SSAdaptiveSupport(BaseAdaptiveSupport):
         self._initial_proposal_params = {}
         # Cache the initial std/covariance
         if self.isdiagonal:
-            self._initial_proposal_params.update({'_std': self._std})
+            self._initial_proposal_params.update({'_std': self._std.copy()})
         else:
-            self._initial_proposal_params.update({'_cov': self._cov})
+            self._initial_proposal_params.update({'_cov': self._cov.copy()})
         
         self._initial_proposal_params.update({'n_accepted': 0})
 

--- a/epsie/proposals/normal.py
+++ b/epsie/proposals/normal.py
@@ -470,7 +470,7 @@ class SSAdaptiveSupport(BaseAdaptiveSupport):
             self._initial_proposal_params.update({'_std': self._std.copy()})
         else:
             self._initial_proposal_params.update({'_cov': self._cov.copy()})
-        
+
         self._initial_proposal_params.update({'n_accepted': 0})
 
 

--- a/epsie/proposals/solid_angle.py
+++ b/epsie/proposals/solid_angle.py
@@ -269,8 +269,9 @@ class AdaptiveIsotropicSolidAngleSupport(BaseAdaptiveSupport):
         Parameters
         ----------
         adaptation_duration: int
-            The number of proposal steps over which to apply the adaptation. No
-            more adaptation will be done once a proposal exceeds this value.
+            The number of proposal steps over which to apply the adaptation.
+            No more adaptation will be done once a proposal exceeds this
+            value.
         start_step : int, optional
             The proposal step when the adaptation phase begins.
         target_rate: float, optional
@@ -283,6 +284,10 @@ class AdaptiveIsotropicSolidAngleSupport(BaseAdaptiveSupport):
         self._decay_const = (adaptation_duration)**(-0.6)
         # this one will be getting updated
         self._log_kappa = numpy.log(self.kappa)
+
+        self._initial_proposal_params = {'_kappa': self.kappa,
+                                         '_log_kappa': self._log_kappa,
+                                         'norm': self._norm}
 
     def _update(self, chain):
         dk = self.nsteps - self.start_step + 1
@@ -300,6 +305,7 @@ class AdaptiveIsotropicSolidAngleSupport(BaseAdaptiveSupport):
     def state(self):
         state = {'nsteps': self._nsteps,
                  'random_state': self.random_state,
+                 'start_step': self.start_step,
                  'kappa': self.kappa}
         return state
 
@@ -307,6 +313,7 @@ class AdaptiveIsotropicSolidAngleSupport(BaseAdaptiveSupport):
         self.random_state = state['random_state']
         self._nsteps = state['nsteps']
         self.kappa = state['kappa']
+        self.start_step = state['start_step']
         # store the log and the normalisation constant
         self._log_kappa = numpy.log(self.kappa)
         self.norm = self._normalisation(self.kappa)

--- a/epsie/samplers/ptsampler.py
+++ b/epsie/samplers/ptsampler.py
@@ -68,9 +68,9 @@ class ParallelTemperedSampler(BaseSampler):
         single core.
     """
     def __init__(self, parameters, model, nchains, betas, swap_interval=1,
-                 proposals=None, adaptive_annealer=None, reset_swap_proposals=False,
-                 default_proposal=None, default_proposal_args=None, seed=None,
-                 pool=None):
+                 proposals=None, adaptive_annealer=None,
+                 reset_swap_proposals=False, default_proposal=None,
+                 default_proposal_args=None, seed=None, pool=None):
         self.parameters = parameters
         self.model = model
         self.set_proposals(proposals, default_proposal, default_proposal_args)

--- a/epsie/samplers/ptsampler.py
+++ b/epsie/samplers/ptsampler.py
@@ -49,6 +49,12 @@ class ParallelTemperedSampler(BaseSampler):
     proposals : list, optional
         List of proposals to use. Any parameters that do not have a proposal
         provided will use the ``default_propsal``.
+    adaptive_annealer : object, optional
+        Adaptive annealing that adjusts the temperature levels during runtime.
+        By default `None`, meaning no annealing.
+    reset_proposals : bool, optional
+        Whether to reset proposals' adaptation after each swap. By default
+        no reset.
     default_proposal : an epsie.Proposal class, optional
         The default proposal to use for parameters not in ``proposals``.
         Default is :py:class:`epsie.proposals.Normal`.
@@ -62,12 +68,14 @@ class ParallelTemperedSampler(BaseSampler):
         single core.
     """
     def __init__(self, parameters, model, nchains, betas, swap_interval=1,
-                 proposals=None, adaptive_annealer=None, default_proposal=None,
-                 default_proposal_args=None, seed=None, pool=None):
+                 proposals=None, adaptive_annealer=None, reset_proposals=False,
+                 default_proposal=None, default_proposal_args=None, seed=None,
+                 pool=None):
         self.parameters = parameters
         self.model = model
         self.set_proposals(proposals, default_proposal, default_proposal_args)
         self.seed = seed
+
         self.pool = pool
         if isinstance(betas, (float, int)):
             # only single temperature; turn into list so things below won't
@@ -77,10 +85,11 @@ class ParallelTemperedSampler(BaseSampler):
             # betas is probably a list or tuple; convert to array so we can use
             # numpy functions
             betas = numpy.array(betas)
-        self.create_chains(nchains, betas, swap_interval, adaptive_annealer)
+        self.create_chains(nchains, betas, swap_interval, adaptive_annealer,
+                           reset_proposals)
 
     def create_chains(self, nchains, betas, swap_interval=1,
-                      adaptive_annealer=None):
+                      adaptive_annealer=None, reset_proposals=False):
         """Creates a list of :py:class:`chain.ParallelTemperedChain`.
 
         Parameters
@@ -96,6 +105,9 @@ class ParallelTemperedSampler(BaseSampler):
         adaptive_annealer : object, optional
             Adaptive anneler adjusting temperatures on the go.
             Default is `None`.
+        reset_proposals : bool, optional
+            Whether to reset proposals' adaptation after each swap. By default
+            no reset.
         """
         if nchains < 1:
             raise ValueError("nchains must be >= 1")
@@ -106,6 +118,7 @@ class ParallelTemperedSampler(BaseSampler):
             [copy.deepcopy(p) for p in self.proposals],
             betas=betas, swap_interval=swap_interval,
             adaptive_annealer=adaptive_annealer,
+            reset_proposals=reset_proposals,
             bit_generator=bg, chain_id=cid)
             for cid, bg in enumerate(bitgens)]
 

--- a/epsie/samplers/ptsampler.py
+++ b/epsie/samplers/ptsampler.py
@@ -52,7 +52,7 @@ class ParallelTemperedSampler(BaseSampler):
     adaptive_annealer : object, optional
         Adaptive annealing that adjusts the temperature levels during runtime.
         By default `None`, meaning no annealing.
-    reset_proposals : bool, optional
+    reset_swap_proposals : bool, optional
         Whether to reset proposals' adaptation after each swap. By default
         no reset.
     default_proposal : an epsie.Proposal class, optional
@@ -68,7 +68,7 @@ class ParallelTemperedSampler(BaseSampler):
         single core.
     """
     def __init__(self, parameters, model, nchains, betas, swap_interval=1,
-                 proposals=None, adaptive_annealer=None, reset_proposals=False,
+                 proposals=None, adaptive_annealer=None, reset_swap_proposals=False,
                  default_proposal=None, default_proposal_args=None, seed=None,
                  pool=None):
         self.parameters = parameters
@@ -86,10 +86,10 @@ class ParallelTemperedSampler(BaseSampler):
             # numpy functions
             betas = numpy.array(betas)
         self.create_chains(nchains, betas, swap_interval, adaptive_annealer,
-                           reset_proposals)
+                           reset_swap_proposals)
 
     def create_chains(self, nchains, betas, swap_interval=1,
-                      adaptive_annealer=None, reset_proposals=False):
+                      adaptive_annealer=None, reset_swap_proposals=False):
         """Creates a list of :py:class:`chain.ParallelTemperedChain`.
 
         Parameters
@@ -105,7 +105,7 @@ class ParallelTemperedSampler(BaseSampler):
         adaptive_annealer : object, optional
             Adaptive anneler adjusting temperatures on the go.
             Default is `None`.
-        reset_proposals : bool, optional
+        reset_swap_proposals : bool, optional
             Whether to reset proposals' adaptation after each swap. By default
             no reset.
         """
@@ -118,7 +118,7 @@ class ParallelTemperedSampler(BaseSampler):
             [copy.deepcopy(p) for p in self.proposals],
             betas=betas, swap_interval=swap_interval,
             adaptive_annealer=adaptive_annealer,
-            reset_proposals=reset_proposals,
+            reset_swap_proposals=reset_swap_proposals,
             bit_generator=bg, chain_id=cid)
             for cid, bg in enumerate(bitgens)]
 

--- a/epsie/samplers/ptsampler.py
+++ b/epsie/samplers/ptsampler.py
@@ -52,7 +52,7 @@ class ParallelTemperedSampler(BaseSampler):
     adaptive_annealer : object, optional
         Adaptive annealing that adjusts the temperature levels during runtime.
         By default `None`, meaning no annealing.
-    reset_swap_proposals : bool, optional
+    reset_after_swap : bool, optional
         Whether to reset proposals' adaptation after each swap. By default
         no reset.
     default_proposal : an epsie.Proposal class, optional
@@ -69,7 +69,7 @@ class ParallelTemperedSampler(BaseSampler):
     """
     def __init__(self, parameters, model, nchains, betas, swap_interval=1,
                  proposals=None, adaptive_annealer=None,
-                 reset_swap_proposals=False, default_proposal=None,
+                 reset_after_swap=False, default_proposal=None,
                  default_proposal_args=None, seed=None, pool=None):
         self.parameters = parameters
         self.model = model
@@ -86,10 +86,10 @@ class ParallelTemperedSampler(BaseSampler):
             # numpy functions
             betas = numpy.array(betas)
         self.create_chains(nchains, betas, swap_interval, adaptive_annealer,
-                           reset_swap_proposals)
+                           reset_after_swap)
 
     def create_chains(self, nchains, betas, swap_interval=1,
-                      adaptive_annealer=None, reset_swap_proposals=False):
+                      adaptive_annealer=None, reset_after_swap=False):
         """Creates a list of :py:class:`chain.ParallelTemperedChain`.
 
         Parameters
@@ -105,7 +105,7 @@ class ParallelTemperedSampler(BaseSampler):
         adaptive_annealer : object, optional
             Adaptive anneler adjusting temperatures on the go.
             Default is `None`.
-        reset_swap_proposals : bool, optional
+        reset_after_swap : bool, optional
             Whether to reset proposals' adaptation after each swap. By default
             no reset.
         """
@@ -118,7 +118,7 @@ class ParallelTemperedSampler(BaseSampler):
             [copy.deepcopy(p) for p in self.proposals],
             betas=betas, swap_interval=swap_interval,
             adaptive_annealer=adaptive_annealer,
-            reset_swap_proposals=reset_swap_proposals,
+            reset_after_swap=reset_after_swap,
             bit_generator=bg, chain_id=cid)
             for cid, bg in enumerate(bitgens)]
 

--- a/test/test_adaptive_normal.py
+++ b/test/test_adaptive_normal.py
@@ -161,7 +161,7 @@ def test_clear_memory(nprocs, proposal_name):
 
 def _extract_pt_std(sampler, proposal):
     std = numpy.zeros((sampler.nchains, sampler.ntemps,
-                                   len(proposal.parameters)))
+                       len(proposal.parameters)))
     for ii, chain in enumerate(sampler.chains):
         for jj, subchain in enumerate(chain.chains):
             thisprop = subchain.proposal_dist.proposals[0]
@@ -177,12 +177,12 @@ def test_resetting(proposal_name):
 
     Setup the sampler, run it for ``ADAPTATION_DURATION``, reset it and check
     that the proposals were reset. After that run it again for
-    ``ADAPTATION_DURATION`` and ensure that the proposal is adapting. After that
-    run it again for ``ADAPTATION_DURATION`` and verity the proposal stopped
-    adapting unless it is the Sivia and Skilling proposal.
+    ``ADAPTATION_DURATION`` and ensure that the proposal is adapting. After
+    that run it again for ``ADAPTATION_DURATION`` and verity the proposal
+    stopped adapting unless it is the Sivia and Skilling proposal.
     """
     nprocs = 1
-    
+
     model = Model()
     proposal = _setup_proposal(model, proposal_name)
     sampler = _create_sampler(model, nprocs, proposals=[proposal])
@@ -192,7 +192,7 @@ def test_resetting(proposal_name):
 
     sampler.run(ADAPTATION_DURATION)
     assert (_extract_pt_std(sampler, proposal) != initial_std).all()
-    
+
     # Reset all chains
     for chain in sampler.chains:
         for subchain in chain.chains:

--- a/test/test_adaptive_normal.py
+++ b/test/test_adaptive_normal.py
@@ -196,7 +196,7 @@ def test_resetting(proposal_name):
     # Reset all chains
     for chain in sampler.chains:
         for subchain in chain.chains:
-            subchain._reset_proposals()
+            subchain.reset_proposals()
 
     # Check we sucessfuly resetted
     assert (_extract_pt_std(sampler, proposal) == initial_std).all()

--- a/test/test_adaptive_normal.py
+++ b/test/test_adaptive_normal.py
@@ -16,7 +16,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """Performs unit tests on the AdaptiveNormal proposals."""
 
-import itertools
 import pytest
 import numpy
 

--- a/test/test_at_normal.py
+++ b/test/test_at_normal.py
@@ -254,7 +254,7 @@ def test_resetting(proposal_name, diagonal, componentwise):
     # Reset all chains
     for chain in sampler.chains:
         for subchain in chain.chains:
-            subchain._reset_proposals()
+            subchain.reset_proposals()
 
     # Check we sucessfuly resetted
     assert (_extract_pt_cov(sampler, proposal, diagonal) == initial_cov).all()

--- a/test/test_at_normal.py
+++ b/test/test_at_normal.py
@@ -206,3 +206,69 @@ def test_clear_memory(name, nprocs):
     model = Model()
     proposal = _setup_proposal(model, name)
     _test_clear_memory(Model, nprocs, SWAP_INTERVAL, proposals=[proposal])
+
+
+def _extract_pt_cov(sampler, proposal, diagonal):
+    N = len(proposal.parameters)
+    if diagonal:
+        cov = numpy.zeros((sampler.nchains, sampler.ntemps, N))
+    else:
+        cov = numpy.zeros((sampler.nchains, sampler.ntemps, N, N))
+
+    for ii, ptchain in enumerate(sampler.chains):
+        for jj, subchain in enumerate(ptchain.chains):
+            thisprop = subchain.proposal_dist.proposals[0]
+            if diagonal:
+                cov[ii, jj, :] = thisprop.std
+            else:
+                cov[ii, jj, :, :] = thisprop.cov
+    return cov
+
+
+@pytest.mark.parametrize('proposal_name', ['at_adaptive_normal'])
+@pytest.mark.parametrize('diagonal', [True, False])
+@pytest.mark.parametrize('componentwise', [True, False])
+def test_resetting(proposal_name, diagonal, componentwise):
+    """
+    Test to ensure that the proposal reset is working.
+
+    Setup the sampler, run it for ``ADAPTATION_DURATION``, reset it and check
+    that the proposals were reset. After that run it again for
+    ``ADAPTATION_DURATION`` and ensure that the proposal is adapting. After
+    that run it again for ``ADAPTATION_DURATION`` and verity the proposal
+    stopped adapting.
+    """
+    nprocs = 1
+
+    model = Model()
+    proposal = _setup_proposal(model, proposal_name, diagonal=diagonal,
+                               componentwise=componentwise)
+    sampler = _create_sampler(model, nprocs, proposals=[proposal])
+
+    # Extract the initial proposal STD
+    initial_cov = _extract_pt_cov(sampler, proposal, diagonal)
+
+    sampler.run(ADAPTATION_DURATION)
+    assert (_extract_pt_cov(sampler, proposal, diagonal) != initial_cov).all()
+
+    # Reset all chains
+    for chain in sampler.chains:
+        for subchain in chain.chains:
+            subchain._reset_proposals()
+
+    # Check we sucessfuly resetted
+    assert (_extract_pt_cov(sampler, proposal, diagonal) == initial_cov).all()
+    # Check that the starting step was bumped up
+    for chain in sampler.chains:
+        for subchain in chain.chains:
+            prop = subchain.proposal_dist.proposals[0]
+            assert prop.start_step == ADAPTATION_DURATION
+
+    # Check that the std is again changing
+    sampler.run(ADAPTATION_DURATION)
+    current_cov = _extract_pt_cov(sampler, proposal, diagonal)
+    assert (current_cov != initial_cov).all()
+
+    # Check that the std stopped changing
+    sampler.run(ADAPTATION_DURATION)
+    assert (_extract_pt_cov(sampler, proposal, diagonal) == current_cov).all()

--- a/test/test_eigenvector.py
+++ b/test/test_eigenvector.py
@@ -142,3 +142,6 @@ def test_clear_memory(nprocs, proposal_name):
     model = Model()
     proposal = _setup_proposal(model, proposal_name)
     _test_clear_memory(Model, nprocs, SWAP_INTERVAL, proposals=[proposal])
+
+if __name__ == '__main__':
+    test_scale_changes(1, "eigenvector")

--- a/test/test_eigenvector.py
+++ b/test/test_eigenvector.py
@@ -142,6 +142,3 @@ def test_clear_memory(nprocs, proposal_name):
     model = Model()
     proposal = _setup_proposal(model, proposal_name)
     _test_clear_memory(Model, nprocs, SWAP_INTERVAL, proposals=[proposal])
-
-if __name__ == '__main__':
-    test_scale_changes(1, "eigenvector")

--- a/test/test_solid_angle.py
+++ b/test/test_solid_angle.py
@@ -106,7 +106,7 @@ def test_resetting(proposal_name):
     sampler = _create_sampler(model, nprocs, proposals=[proposal])
 
     initial_kappas = _extract_pt_kappas(sampler)
-    # Run the sampler for a bit 
+    # Run the sampler for a bit
     sampler.run(ADAPTATION_DURATION)
     assert (_extract_pt_kappas(sampler) != initial_kappas).all()
 

--- a/test/test_solid_angle.py
+++ b/test/test_solid_angle.py
@@ -113,7 +113,7 @@ def test_resetting(proposal_name):
     # Reset all chains
     for chain in sampler.chains:
         for subchain in chain.chains:
-            subchain._reset_proposals()
+            subchain.reset_proposals()
 
     # Check we sucessfuly resetted
     assert (_extract_pt_kappas(sampler) == initial_kappas).all()

--- a/test/test_solid_angle.py
+++ b/test/test_solid_angle.py
@@ -17,10 +17,12 @@
 """Performs unit tests on the solid angle proposals."""
 
 import pytest
+import numpy
 
 from epsie.proposals import (IsotropicSolidAngle, AdaptiveIsotropicSolidAngle)
 from _utils import SolidAngleModel
 
+from test_ptsampler import _create_sampler
 from test_ptsampler import test_checkpointing as _test_checkpointing
 from test_ptsampler import test_seed as _test_seed
 from test_ptsampler import test_clear_memory as _test_clear_memory
@@ -75,3 +77,57 @@ def test_clear_memory(nprocs, proposal_name):
     proposal = _setup_proposal(model, proposal_name)
     _test_clear_memory(SolidAngleModel, nprocs, SWAP_INTERVAL,
                        proposals=[proposal])
+
+
+def _extract_pt_kappas(sampler):
+    kappas = numpy.zeros((sampler.nchains, sampler.ntemps))
+    for ii, chain in enumerate(sampler.chains):
+        for jj, subchain in enumerate(chain.chains):
+            thisprop = subchain.proposal_dist.proposals[0]
+            kappas[ii, jj] = thisprop.kappa
+    return kappas
+
+
+@pytest.mark.parametrize("proposal_name", ["adaptive_isotropic_solid_angle"])
+def test_resetting(proposal_name):
+    """
+    Test to ensure that the proposal reset is working.
+
+    Setup the sampler, run it for ``ADAPTATION_DURATION``, reset it and check
+    that the proposals were reset. After that run it again for
+    ``ADAPTATION_DURATION`` and ensure that the proposal is adapting. After
+    that run it again for ``ADAPTATION_DURATION`` and verify the proposal
+    stopped adapting.
+    """
+    nprocs = 1
+    model = SolidAngleModel()
+    proposal = _setup_proposal(model, proposal_name)
+
+    sampler = _create_sampler(model, nprocs, proposals=[proposal])
+
+    initial_kappas = _extract_pt_kappas(sampler)
+    # Run the sampler for a bit 
+    sampler.run(ADAPTATION_DURATION)
+    assert (_extract_pt_kappas(sampler) != initial_kappas).all()
+
+    # Reset all chains
+    for chain in sampler.chains:
+        for subchain in chain.chains:
+            subchain._reset_proposals()
+
+    # Check we sucessfuly resetted
+    assert (_extract_pt_kappas(sampler) == initial_kappas).all()
+    # Check that the starting step was bumped up
+    for chain in sampler.chains:
+        for subchain in chain.chains:
+            prop = subchain.proposal_dist.proposals[0]
+            assert prop.start_step == ADAPTATION_DURATION
+
+    # Check that the kappa is again changing
+    sampler.run(ADAPTATION_DURATION)
+    current_kappas = _extract_pt_kappas(sampler)
+    assert (current_kappas != initial_kappas).all()
+
+    # Check that the std stopped changing
+    sampler.run(ADAPTATION_DURATION)
+    assert (_extract_pt_kappas(sampler) == current_kappas).all()


### PR DESCRIPTION
Start resetting the adaptation when a temperature swap is performed and add a cost function to penalise temperature swaps if a walker stays long enough at a single temperature.

TO DO:

1. Add unit tests
2. Correct for behaviour if `start_iteration != 1`
3. Check transdimensional support. Reset adaptation of newly created proposals.
4. Cost function
5. Test it, test it, test it.



Open questions:

1. Should the adaption always be reset?