### PR TITLE
Implementation of fast parameters dragging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+build/
+epsie.egg-info/
+.DS_Store
+reinstall_epsie.sh
+*.pyc
+scratch_* 
+.ipynb_checkpoints/*

--- a/epsie/chain/__init__.py
+++ b/epsie/chain/__init__.py
@@ -18,3 +18,4 @@
 from .chaindata import ChainData
 from .chain import Chain
 from .ptchain import (ParallelTemperedChain, DynamicalAnnealer)
+from .fastchain import FastChain

--- a/epsie/chain/chain.py
+++ b/epsie/chain/chain.py
@@ -85,6 +85,7 @@ class Chain(BaseChain):
     proposal_dist : JointProposal
         The joint proposal used for all parameters.
     """
+
     def __init__(self, parameters, model, proposals, bit_generator=None,
                  chain_id=0, beta=1.):
         self.parameters = parameters

--- a/epsie/chain/fastchain.py
+++ b/epsie/chain/fastchain.py
@@ -38,51 +38,58 @@ class FastChain(Chain):
     """
     _is_fast = True
 
-    def __init__(self, parameters, model, proposals, slow_parameters, nfast, bit_generator=None):
-        # Initialise the parent chain
-        # Add a setter for this
-        self.nfast = nfast
-
-        # Make sure there is no overlap between parameters and slow_parameters
-        self.slow_parameters = slow_parameters
-
+    def __init__(self, parameters, model, proposals, slow_parameters, ndrags,
+                 bit_generator=None):
         self._current_slow = None
         self._proposed_slow = None
+        self._ndrags = None
 
+        self.slow_parameters = slow_parameters
+        self.ndrags = ndrags
+
+        # Must be renamed because we will pass ``self.model`` to the parent
+        # chain instead
         self.original_model = model
 
+        # To store the likelihoods when evaluated with fixed slow and changing
+        # fast parameters. Necessary because by default the chain is storing
+        # only the interpolated probabilities.
         self._dragged_stats = ChainData(["lpost0", "lpostf"])
-        self._dragged_stats.set_len(nfast)
+        self._dragged_stats.set_len(ndrags)
 
-
+        # Initialise the parent chain
         super().__init__(parameters, self.model, proposals, bit_generator,
                          chain_id=0, beta=1.)
 
 
     @property
     def current_slow(self):
+        """Current slow parameters."""
         if self._current_slow is None:
             raise ValueError("``current_slow`` not set!")
         return self._current_slow
 
     @current_slow.setter
     def current_slow(self, current_slow):
+        """Sets the current fast parameters."""
         self._current_slow = self._set_slow_params(current_slow)
 
     @property
     def proposed_slow(self):
+        """Proposed slow parameters."""
         if self._proposed_slow is None:
             raise ValueError("``proposed_slow`` not set!")
         return self._proposed_slow
 
     @proposed_slow.setter
     def proposed_slow(self, proposed_slow):
+        """Sets the proposed slow parameters."""
         self._proposed_slow = self._set_slow_params(proposed_slow)
 
     def _set_slow_params(self, positions):
         """
-        Check that parameters in `self.slow_parameters` 
-
+        Check that slow parameters in ``positions`` match the expected slow
+        parameters and that no extra parameters are given.
         """
         if positions is None:
             return None
@@ -101,6 +108,18 @@ class FastChain(Chain):
 
         return checked_positions
 
+    @property
+    def ndrags(self):
+        """Number of fast parameter dragging step."""
+        return self._ndrags
+
+    @ndrags.setter
+    def ndrags(self, ndrags):
+        """Sets the number of dragging steps."""
+        if not ndrags > 1:
+            raise ValueError("`ndrags` must be larger than 1.")
+        self._ndrags = ndrags
+
     def model(self, **proposed):
         """
         Interpolated posterior between the previous and proposed slow
@@ -108,7 +127,7 @@ class FastChain(Chain):
         of completed fast steps.
         """
         # Fraction of completed fast steps, + 1 to account for the start pos
-        prog = (self.iteration + 1) / self.nfast
+        prog = (self.iteration + 1) / self.ndrags
         if prog > 1:
             raise ValueError("Chain should have been cleared.")
         # Call the models with the slow and fast parameters
@@ -149,7 +168,7 @@ class FastChain(Chain):
 
     def dragging_clear(self):
         self.clear()  # clear the parent chain
-        self._dragged_stats.clear(self.nfast)  # clear the dragged stats
+        self._dragged_stats.clear(self.ndrags)  # clear the dragged stats
         self._lastclear = 0  # we don't want to use this
         # Reset the iterations
         self._iteration = 0
@@ -161,5 +180,5 @@ class FastChain(Chain):
         """
         Util function to test the chain, will later remove. 
         """
-        for __ in range(1, self.nfast):
+        for __ in range(1, self.ndrags):
             self.step()

--- a/epsie/chain/fastchain.py
+++ b/epsie/chain/fastchain.py
@@ -34,7 +34,7 @@ class FastChain(Chain):
     Clear up the chain at the end!
 
     Warn the user that blobs are not supported ?
-    
+
     """
     _is_fast = True
 
@@ -45,7 +45,7 @@ class FastChain(Chain):
 
         # Make sure there is no overlap between parameters and slow_parameters
         self.slow_parameters = slow_parameters
-        
+
         self._current_slow = None
         self._proposed_slow = None
 
@@ -53,13 +53,13 @@ class FastChain(Chain):
 
         self._dragged_stats = ChainData(["lpost0", "lpostf"])
         self._dragged_stats.set_len(nfast)
-        
+
 
         super().__init__(parameters, self.model, proposals, bit_generator,
                          chain_id=0, beta=1.)
-        
-    
-    @property        
+
+
+    @property
     def current_slow(self):
         if self._current_slow is None:
             raise ValueError("``current_slow`` not set!")
@@ -69,7 +69,7 @@ class FastChain(Chain):
     def current_slow(self, current_slow):
         self._current_slow = self._set_slow_params(current_slow)
 
-    @property        
+    @property
     def proposed_slow(self):
         if self._proposed_slow is None:
             raise ValueError("``proposed_slow`` not set!")
@@ -82,7 +82,7 @@ class FastChain(Chain):
     def _set_slow_params(self, positions):
         """
         Check that parameters in `self.slow_parameters` 
-        
+
         """
         if positions is None:
             return None
@@ -93,21 +93,21 @@ class FastChain(Chain):
             if val is None:
                 raise KeyError("Slow parameter ``{}`` missing position"
                                .format(par))
-            
+
             checked_positions.update({par: val})
         if len(positions) > 0:
             raise ValueError("Unrecognised slow parameters: ``{}``"
                              .format(list(positions.keys())))
 
         return checked_positions
-        
+
     def model(self, **proposed):
         """
         Interpolated posterior.
 
         """
 
-        # Check how indexed when proposing the first step.        
+        # Check how indexed when proposing the first step.
         prog = (self.iteration + 1) / self.nfast
 
         if prog > 1:
@@ -126,7 +126,7 @@ class FastChain(Chain):
 
         # We want to store the start positions
         index = len(self) + int(~numpy.isnan(self._dragged_stats[0]["lpost0"]))
-        
+
         self._dragged_stats[index] = sum(r0), sum(r1)
 
         f = lambda x,y: (1 - prog) * x + prog * y
@@ -136,12 +136,12 @@ class FastChain(Chain):
 
         return logl, logp
 
-    @property        
+    @property
     def dragging_logar(self):
         """
         Partial acceptance, will still have to be multiplied by the slow param
         proposal.
-        
+
         """
         # TODO Return error if fast dragging not completed yet
         stats = self._dragged_stats
@@ -150,12 +150,12 @@ class FastChain(Chain):
         if numpy.isnan(logar):
             raise RuntimeError("Fast dragging not completed yet.")
         return logar
-    
+
     def dragging_clear(self):
         self.clear()  # clear the parent chain
         self._dragged_stats.clear(self.nfast)  # clear the dragged stats
         self._lastclear = 0  # we don't want to use this
-        # Reset the iterations 
+        # Reset the iterations
         self._iteration = 0
         # Reset the current and proposed slow parameters
         self.current_slow = None
@@ -167,9 +167,3 @@ class FastChain(Chain):
         """
         for __ in range(1, self.nfast):
             self.step()
-
-
-
-    
-
-

--- a/epsie/chain/fastchain.py
+++ b/epsie/chain/fastchain.py
@@ -38,13 +38,13 @@ class FastChain(Chain):
     """
     _is_fast = True
 
-    def __init__(self, parameters, model, proposals, parameters_slow, nfast, bit_generator=None):
+    def __init__(self, parameters, model, proposals, slow_parameters, nfast, bit_generator=None):
         # Initialise the parent chain
         # Add a setter for this
         self.nfast = nfast
 
         # Make sure there is no overlap between parameters and slow_parameters
-        self.parameters_slow = parameters_slow
+        self.slow_parameters = slow_parameters
         
         self._current_slow = None
         self._proposed_slow = None
@@ -81,14 +81,14 @@ class FastChain(Chain):
 
     def _set_slow_params(self, positions):
         """
-        Check that parameters in `self.parameters_slow` 
+        Check that parameters in `self.slow_parameters` 
         
         """
         if positions is None:
             return None
         positions = copy(positions)
         checked_positions = {}
-        for par in self.parameters_slow:
+        for par in self.slow_parameters:
             val = positions.pop(par, None)
             if val is None:
                 raise KeyError("Slow parameter ``{}`` missing position"

--- a/epsie/chain/fastchain.py
+++ b/epsie/chain/fastchain.py
@@ -1,0 +1,144 @@
+# Copyright (C) 2022  Richard Stiskalek, Collin Capano
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""Classes for individual Markov chains."""
+
+from copy import copy
+
+import numpy
+
+# from epsie.proposals import JointProposal
+
+# from .base import BaseChain
+# from .chaindata import (ChainData, detect_dtypes)
+from .chain import Chain
+
+
+class FastChain(Chain):
+    """
+    A fast parameters Markov chain.
+
+    Clear up the chain at the end!
+
+    Warn the user that blobs are not supported ?
+    
+    """
+    _is_fast = True
+
+    def __init__(self, parameters, model, proposals, parameters_slow, nfast, bit_generator=None):
+        # Initialise the parent chain
+        # Add a setter for this
+        self.nfast = nfast
+
+        # Make sure there is no overlap between parameters and slow_parameters
+        self.parameters_slow = parameters_slow
+        
+        self._current_slow = None
+        self._proposed_slow = None
+
+        self.original_model = model
+
+
+        super().__init__(parameters, self.model, proposals, bit_generator,
+                         chain_id=0, beta=1.)
+        
+    
+    @property        
+    def current_slow(self):
+        if self._current_slow is None:
+            raise ValueError("``current_slow`` not set!")
+        return self._current_slow
+
+    @current_slow.setter
+    def current_slow(self, current_slow):
+        self._current_slow = self._set_slow_params(current_slow)
+
+    @property        
+    def proposed_slow(self):
+        if self._proposed_slow is None:
+            raise ValueError("``proposed_slow`` not set!")
+        return self._proposed_slow
+
+    @proposed_slow.setter
+    def proposed_slow(self, proposed_slow):
+        self._proposed_slow = self._set_slow_params(proposed_slow)
+
+    def _set_slow_params(self, positions):
+        """
+        Check that parameters in `self.parameters_slow` 
+        
+        """
+        positions = copy(positions)
+        checked_positions = {}
+        for par in self.parameters_slow:
+            val = positions.pop(par, None)
+            if val is None:
+                raise KeyError("Slow parameter ``{}`` missing position"
+                               .format(par))
+            
+            checked_positions.update({par: val})
+        if len(positions) > 0:
+            raise ValueError("Unrecognised slow parameters: ``{}``"
+                             .format(list(positions.keys())))
+
+        return checked_positions
+        
+    def model(self, **proposed):
+        """
+        Interpolated posterior.
+
+        """
+
+        print("Hmmm")
+
+        # Check how indexed when proposing the first step.        
+        prog = (self.iteration + 1) / self.nfast
+
+        if prog > 1:
+            raise ValueError("Chain should have been cleared.")
+
+
+        r0 = self.original_model(**{**proposed, **self.current_slow})
+        r1 = self.original_model(**{**proposed, **self.proposed_slow})
+
+        if self._hasblobs:
+            raise NotImplementedError("Blobs not supported")
+        else:
+            ll0, lp0 = r0
+            ll1, lp1 = r1
+
+        f = lambda x,y: (1 - prog) * x + prog * y
+
+        logl = f(ll0, ll1)
+        logp = f(lp0, lp1)
+
+
+        return logl, logp
+
+        
+    def dragging_acceptance(self):
+        pass
+
+    
+    def fast_stepping(self):
+        """
+        Util function to test the chain, will later remove. 
+        """
+        for __ in range(self.nfast):
+            self.step()
+
+    
+
+

--- a/epsie/chain/fastchain.py
+++ b/epsie/chain/fastchain.py
@@ -61,7 +61,6 @@ class FastChain(Chain):
         super().__init__(parameters, self.model, proposals, bit_generator,
                          chain_id=0, beta=1.)
 
-
     @property
     def current_slow(self):
         """Current slow parameters."""
@@ -148,7 +147,9 @@ class FastChain(Chain):
         self._dragged_stats[index] = sum(r0), sum(r1)
 
         # Interpolation -- sum of log pdfs weighted by how many fast steps done
-        f = lambda x,y: (1 - prog) * x + prog * y
+        def f(x, y):
+            return (1 - prog) * x + prog * y
+
         return f(ll0, ll1), f(lp0, lp1)
 
     @property
@@ -178,7 +179,7 @@ class FastChain(Chain):
 
     def fast_stepping(self):
         """
-        Util function to test the chain, will later remove. 
+        Util function to test the chain, will later remove.
         """
         for __ in range(1, self.ndrags):
             self.step()


### PR DESCRIPTION
Fast parameters dragging as defined in [arxiv.org/abs/math/0502099](https://arxiv.org/abs/math/0502099). The idea is to suggest a new "slow" parameter and perform many MCMC steps using an interpolated posterior between its old (using old slow parameters) and new value.

Implements a new chain class ``FastChain`` which handles the stepping. In the current stage it's main functionality is to perform steps in the fast parameters, calculate the interpolated posterior and make calls to the user's posterior.

The "slow" parameters are ones whose contribution  to the posterior is slow to compute. The user is assumed to have a "caching" system in hand such that the output values of slow functions are cached for equal inputs (at least for the last few values of slow parameters).

Work in progress. Need to implement the acceptance ratio, clearing the chain, setting its scratch length and tie this back to a regular MH chain.

It would be useful to define a wrapper for functions of slow parameters that caches their values.