### PR TITLE
Pin coverage to version 6.2 to stop pool hanging in pytest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
         pip install flake8
         pip install -r requirements.txt
         pip install -r companion.txt
+        pip install "coverage==6.2"
         pip install coveralls
         pip install .
     - name: Lint with flake8


### PR DESCRIPTION
All of our tests have been failing on github in python 3.8 and 3.9 when using the multiprocessing pool. It looks like this is due to a bug that was introduced in version 6.3 of coverage -- see [Issue 1310](https://github.com/nedbat/coveragepy/issues/1310) on the coverage repo. This fixes this by pinning coverage to the older version.